### PR TITLE
Adds the primary attribute to the Address schema

### DIFF
--- a/app/models/scimitar/schema/address.rb
+++ b/app/models/scimitar/schema/address.rb
@@ -10,6 +10,7 @@ module Scimitar
       def self.scim_attributes
         @scim_attributes ||= [
           Attribute.new(name: 'type',          type: 'string'),
+          Attribute.new(name: 'primary',       type: 'boolean'),
           Attribute.new(name: 'formatted',     type: 'string'),
           Attribute.new(name: 'streetAddress', type: 'string'),
           Attribute.new(name: 'locality',      type: 'string'),


### PR DESCRIPTION
**What this does:**
Adds a primary _boolean_ attribute to `Schema::Address`. There is a note in the [Specification versus implementation](https://github.com/RIPAGlobal/scimitar#specification-versus-implementation) section regarding the the use of `primary` in several complex types on a User. 

**Why?**
Okta sends a `primary` attribute with the addresses list. This resolves the resulting _unknown attribute_ error.

