### PR TITLE
Fix patch replace when path is omitted

### DIFF
--- a/app/models/scimitar/resources/mixin.rb
+++ b/app/models/scimitar/resources/mixin.rb
@@ -902,7 +902,11 @@ module Scimitar
                     altering_hash[path_component] = value
                   end
                 when 'replace'
-                  altering_hash[path_component] = value
+                  if path_component == 'root'
+                    altering_hash[path_component].merge!(value)
+                  else
+                    altering_hash[path_component] = value
+                  end
                 when 'remove'
                   altering_hash.delete(path_component)
               end

--- a/spec/models/scimitar/resources/mixin_spec.rb
+++ b/spec/models/scimitar/resources/mixin_spec.rb
@@ -1747,6 +1747,24 @@ RSpec.describe Scimitar::Resources::Mixin do
                 expect(scim_hash['emails'][0]['type' ]).to eql('work')
                 expect(scim_hash['emails'][0]['value']).to eql('work@test.com')
               end
+
+              context 'when prior value already exists, and no path' do
+                it 'simple value: overwrites' do
+                  path      = [ 'root' ]
+                  scim_hash = { 'root' => { 'userName' => 'bar', 'active' => true } }.with_indifferent_case_insensitive_access()
+
+                  @instance.send(
+                    :from_patch_backend!,
+                    nature:        'replace',
+                    path:          path,
+                    value:         { 'active' => false }.with_indifferent_case_insensitive_access(),
+                    altering_hash: scim_hash
+                  )
+
+                  expect(scim_hash['root']['userName']).to eql('bar')
+                  expect(scim_hash['root']['active']).to eql(false)
+                end
+              end
             end # context 'when value is not present' do
           end # "context 'replace' do"
 


### PR DESCRIPTION
This PR is to fix a particular request from Okta, but is likely more widely useful. We came across this when Okta attempts to deactivate a User. They use a `PATCH` request like so:

```
curl --location --request PATCH '$SCIM_URL/Users/$USER_ID' \
--header 'Content-Type:  application/scim+json' \
--header 'Authorization: Bearer $SCIM_TOKEN' \
--data-raw '   {
     "schemas":
       ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
     "Operations":[{
       "op":"replace",
       "value": {
         "active": false
       }
     }]
   }    '
```

This wasn't working as intended, however a request like this _was_ working:


```
curl --location --request PATCH '$SCIM_URL/Users/$USER_ID' \
--header 'Content-Type:  application/scim+json' \
--header 'Authorization: Bearer $SCIM_TOKEN' \
--data-raw '   {
     "schemas":
       ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
       "Operations": [{
           "op": "Replace",
           "path": "active",
           "value": false
        }]
   }'    
```
