### PR TITLE
Address issue #35, with caveats noted in issue #35 discussion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.3.0 (2023-01-17)
+
+* Address https://github.com/RIPAGlobal/scimitar/issues/35. Declaring primary key in the ActiveRecord model would solve most of the problems described, but v2.2.0 did introduce a default order clause that would trip up a model with a different primary key name; this is now fixed. In any case, it may be possible to avoid declaring the primary key override in the model entirely if using Scimitar v2.3.0, should that be your wish. This is in effect an edge case new feature, which is why the gem's minor version has been bumped up.
+
 # 2.2.0 (2023-01-13)
 
 * Bump local development Ruby to v3.2.0, including it in the test matrix and in effect creating "official" support for that Ruby version.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    scimitar (2.2.0)
+    scimitar (2.3.0)
       rails (~> 7.0)
 
 GEM
@@ -87,7 +87,7 @@ GEM
     date (3.3.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    doggo (1.2.0)
+    doggo (1.3.0)
       rspec-core (~> 3.10)
     erubi (1.12.0)
     globalid (1.0.0)
@@ -124,7 +124,7 @@ GEM
     psych (5.0.1)
       stringio
     racc (1.6.2)
-    rack (2.2.5)
+    rack (2.2.6)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (7.0.4)
@@ -161,7 +161,7 @@ GEM
     rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.2)
+    rspec-mocks (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-rails (5.1.2)

--- a/lib/scimitar/version.rb
+++ b/lib/scimitar/version.rb
@@ -3,11 +3,11 @@ module Scimitar
   # Gem version. If this changes, be sure to re-run "bundle install" or
   # "bundle update".
   #
-  VERSION = '2.2.0'
+  VERSION = '2.3.0'
 
   # Date for VERSION. If this changes, be sure to re-run "bundle install"
   # or "bundle update".
   #
-  DATE = '2023-01-13'
+  DATE = '2023-01-17'
 
 end

--- a/spec/apps/dummy/app/controllers/mock_groups_controller.rb
+++ b/spec/apps/dummy/app/controllers/mock_groups_controller.rb
@@ -1,4 +1,4 @@
-class MockUsersController < Scimitar::ActiveRecordBackedResourcesController
+class MockGroupsController < Scimitar::ActiveRecordBackedResourcesController
 
   protected
 

--- a/spec/apps/dummy/app/models/mock_group.rb
+++ b/spec/apps/dummy/app/models/mock_group.rb
@@ -58,7 +58,7 @@ class MockGroup < ActiveRecord::Base
 
           case type.downcase
             when 'user'
-              MockUser.find_by_id(id)
+              MockUser.find_by_primary_key(id)
             when 'group'
               MockGroup.find_by_id(id)
             else

--- a/spec/apps/dummy/app/models/mock_user.rb
+++ b/spec/apps/dummy/app/models/mock_user.rb
@@ -1,11 +1,13 @@
 class MockUser < ActiveRecord::Base
 
+  self.primary_key = :primary_key
+
   # ===========================================================================
   # TEST ATTRIBUTES - see db/migrate/20210304014602_create_mock_users.rb etc.
   # ===========================================================================
 
   READWRITE_ATTRS = %w{
-    id
+    primary_key
     scim_uid
     username
     first_name
@@ -38,7 +40,7 @@ class MockUser < ActiveRecord::Base
 
   def self.scim_attributes_map
     return {
-      id:         :id,
+      id:         :primary_key,
       externalId: :scim_uid,
       userName:   :username,
       name:       {
@@ -92,7 +94,7 @@ class MockUser < ActiveRecord::Base
 
   def self.scim_queryable_attributes
     return {
-      'id'                => { column: :id },
+      'id'                => { column: :primary_key },
       'externalId'        => { column: :scim_uid },
       'meta.lastModified' => { column: :updated_at },
       'name.givenName'    => { column: :first_name },

--- a/spec/apps/dummy/config/routes.rb
+++ b/spec/apps/dummy/config/routes.rb
@@ -6,12 +6,15 @@
 Rails.application.routes.draw do
   mount Scimitar::Engine, at: '/'
 
-  get    'Users',     to: 'mock_users#index'
-  get    'Users/:id', to: 'mock_users#show'
-  post   'Users',     to: 'mock_users#create'
-  put    'Users/:id', to: 'mock_users#replace'
-  patch  'Users/:id', to: 'mock_users#update'
-  delete 'Users/:id', to: 'mock_users#destroy'
+  get    'Users',      to: 'mock_users#index'
+  get    'Users/:id',  to: 'mock_users#show'
+  post   'Users',      to: 'mock_users#create'
+  put    'Users/:id',  to: 'mock_users#replace'
+  patch  'Users/:id',  to: 'mock_users#update'
+  delete 'Users/:id',  to: 'mock_users#destroy'
+
+  get    'Groups',     to: 'mock_groups#index'
+  get    'Groups/:id', to: 'mock_groups#show'
 
   # For testing blocks passed to ActiveRecordBackedResourcesController#destroy
   #

--- a/spec/apps/dummy/db/migrate/20210304014602_create_mock_users.rb
+++ b/spec/apps/dummy/db/migrate/20210304014602_create_mock_users.rb
@@ -1,6 +1,7 @@
 class CreateMockUsers < ActiveRecord::Migration[6.1]
   def change
-    create_table :mock_users do |t|
+    create_table :mock_users, id: :uuid, primary_key: :primary_key do |t|
+      t.timestamps
 
       t.text :scim_uid
       t.text :username
@@ -9,7 +10,6 @@ class CreateMockUsers < ActiveRecord::Migration[6.1]
       t.text :work_email_address
       t.text :home_email_address
       t.text :work_phone_number
-
     end
   end
 end

--- a/spec/apps/dummy/db/migrate/20210308044214_create_join_table_mock_groups_mock_users.rb
+++ b/spec/apps/dummy/db/migrate/20210308044214_create_join_table_mock_groups_mock_users.rb
@@ -1,8 +1,13 @@
 class CreateJoinTableMockGroupsMockUsers < ActiveRecord::Migration[6.1]
   def change
-    create_join_table :mock_groups, :mock_users do |t|
-      t.index [:mock_group_id, :mock_user_id]
-      t.index [:mock_user_id, :mock_group_id]
+    create_table :mock_groups_users, id: false do | t |
+      t.references :mock_group, foreign_key: true, type: :int8, index: true, null: false
+      t.references :mock_user,                     type: :uuid, index: true, null: false, primary_key: :primary_key
+
+      # The 'foreign_key:' option (used above) only works for 'id' column names
+      # but the test data has a column named 'primary_key' for 'mock_users'.
+      #
+      t.foreign_key :mock_users, primary_key: :primary_key
     end
   end
 end

--- a/spec/apps/dummy/db/migrate/20230109012729_add_timestamps_to_mock_user.rb
+++ b/spec/apps/dummy/db/migrate/20230109012729_add_timestamps_to_mock_user.rb
@@ -1,5 +1,0 @@
-class AddTimestampsToMockUser < ActiveRecord::Migration[7.0]
-  def change
-    add_timestamps :mock_users
-  end
-end

--- a/spec/apps/dummy/db/schema.rb
+++ b/spec/apps/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_09_012729) do
+ActiveRecord::Schema[7.0].define(version: 2021_03_08_044214) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,12 +23,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_09_012729) do
 
   create_table "mock_groups_users", id: false, force: :cascade do |t|
     t.bigint "mock_group_id", null: false
-    t.bigint "mock_user_id", null: false
-    t.index ["mock_group_id", "mock_user_id"], name: "index_mock_groups_users_on_mock_group_id_and_mock_user_id"
-    t.index ["mock_user_id", "mock_group_id"], name: "index_mock_groups_users_on_mock_user_id_and_mock_group_id"
+    t.uuid "mock_user_id", null: false
+    t.index ["mock_group_id"], name: "index_mock_groups_users_on_mock_group_id"
+    t.index ["mock_user_id"], name: "index_mock_groups_users_on_mock_user_id"
   end
 
-  create_table "mock_users", force: :cascade do |t|
+  create_table "mock_users", primary_key: "primary_key", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.text "scim_uid"
     t.text "username"
     t.text "first_name"
@@ -36,8 +38,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_09_012729) do
     t.text "work_email_address"
     t.text "home_email_address"
     t.text "work_phone_number"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "mock_groups_users", "mock_groups"
+  add_foreign_key "mock_groups_users", "mock_users", primary_key: "primary_key"
 end

--- a/spec/models/scimitar/lists/query_parser_spec.rb
+++ b/spec/models/scimitar/lists/query_parser_spec.rb
@@ -405,19 +405,19 @@ RSpec.describe Scimitar::Lists::QueryParser do
       query = @instance.to_activerecord_query(MockUser.all)
 
       expect(query.count).to eql(1)
-      expect(query.pluck(:id)).to eql([user_1.id])
+      expect(query.pluck(:primary_key)).to eql([user_1.primary_key])
 
       @instance.parse('name.givenName sw J') # First name starts with 'J'
       query = @instance.to_activerecord_query(MockUser.all)
 
       expect(query.count).to eql(2)
-      expect(query.pluck(:id)).to match_array([user_1.id, user_2.id])
+      expect(query.pluck(:primary_key)).to match_array([user_1.primary_key, user_2.primary_key])
 
       @instance.parse('name.familyName ew he') # Last name ends with 'he'
       query = @instance.to_activerecord_query(MockUser.all)
 
       expect(query.count).to eql(1)
-      expect(query.pluck(:id)).to eql([user_2.id])
+      expect(query.pluck(:primary_key)).to eql([user_2.primary_key])
 
       # Test presence
 
@@ -425,7 +425,7 @@ RSpec.describe Scimitar::Lists::QueryParser do
       query = @instance.to_activerecord_query(MockUser.all)
 
       expect(query.count).to eql(2)
-      expect(query.pluck(:id)).to match_array([user_1.id, user_2.id])
+      expect(query.pluck(:primary_key)).to match_array([user_1.primary_key, user_2.primary_key])
 
       # Test a simple not-equals, but use a custom starting scope. Note that
       # the query would find "user_3" *except* there is no first name defined
@@ -435,7 +435,7 @@ RSpec.describe Scimitar::Lists::QueryParser do
       query = @instance.to_activerecord_query(MockUser.where.not('first_name' => 'John'))
 
       expect(query.count).to eql(1)
-      expect(query.pluck(:id)).to match_array([user_1.id])
+      expect(query.pluck(:primary_key)).to match_array([user_1.primary_key])
     end
 
     context 'when mapped to multiple columns' do
@@ -499,7 +499,7 @@ RSpec.describe Scimitar::Lists::QueryParser do
           query = @instance.to_activerecord_query(MockUser.all)
 
           expect(query.count).to eql(1)
-          expect(query.pluck(:id)).to match_array([user_2.id])
+          expect(query.pluck(:primary_key)).to match_array([user_2.primary_key])
         end
       end # "context 'simple AND' do"
 
@@ -520,7 +520,7 @@ RSpec.describe Scimitar::Lists::QueryParser do
           query = @instance.to_activerecord_query(MockUser.all)
 
           expect(query.count).to eql(2)
-          expect(query.pluck(:id)).to match_array([user_1.id, user_2.id])
+          expect(query.pluck(:primary_key)).to match_array([user_1.primary_key, user_2.primary_key])
         end
       end # "context 'simple OR' do"
 
@@ -546,7 +546,7 @@ RSpec.describe Scimitar::Lists::QueryParser do
           query = @instance.to_activerecord_query(MockUser.all)
 
           expect(query.count).to eql(3)
-          expect(query.pluck(:id)).to match_array([user_1.id, user_2.id, user_3.id])
+          expect(query.pluck(:primary_key)).to match_array([user_1.primary_key, user_2.primary_key, user_3.primary_key])
         end
       end # "context 'combined AND and OR' do"
 


### PR DESCRIPTION
Address https://github.com/RIPAGlobal/scimitar/issues/35. Declaring primary key in the ActiveRecord model would solve most of the problems described, but v2.2.0 did introduce a default order clause that would trip up a model with a different primary key name; this is now fixed. In any case, it may be possible to avoid declaring the primary key override in the model entirely if using Scimitar v2.3.0, should that be your wish. This is in effect an edge case new feature, which is why the gem's minor version has been bumped up.

Maintenance `bundle update` included, which amongst other things pulls in "officially supports Ruby 3.2.0" Doggo v1.3 (only relevant for developers running the gem's tests).

Hide white space while viewing changes for a cleaner diff.