### PR TITLE
Handle possibly non-compliant PATCH payloads (for real-world use cases)

### DIFF
--- a/spec/apps/dummy/config/routes.rb
+++ b/spec/apps/dummy/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
   get    'Groups',     to: 'mock_groups#index'
   get    'Groups/:id', to: 'mock_groups#show'
+  patch  'Groups/:id', to: 'mock_groups#update'
 
   # For testing blocks passed to ActiveRecordBackedResourcesController#destroy
   #


### PR DESCRIPTION
Tolerates the Microsoft form of patch-remove payload (in a fairly gene…ric way) and the Salesforce payload (as a limited special case) - addresses https://github.com/RIPAGlobal/scimitar/issues/43.

The [RFC way to remove a user from a group](https://www.rfc-editor.org/rfc/rfc7644#section-3.5.2.2) is via a filter:

```json
{ "schemas":
       ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
     "Operations": [
       {
         "op":"remove",
         "path":
           "members[value eq\"2819c223...919d-413861904646\"]"
       }
     ]
   }
```

...with [_arguably_ forms of payload that attempt to specify the user(s) to remove in the `value` parameter](https://github.com/simpleidserver/SimpleIdServer/issues/164#issuecomment-871456758) rather than a filter in `path`, having that `value` ignored with the `path` of just `members` then matching the RFC's "remove all users" example:

```json
   {
     "schemas":
       ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
     "Operations": [
       {
         "op":"remove","path":"members"
       }
     ]
   }
```

That's all well and good, but if you *do* have a SCIM call coming in which clearly expects to give a specific user ID for removal, but your implementation just empties the entire group... Well, that's not a great failure mode. As discussed in issue #43, then, this PR accepts the [Microsoft form of removal payload](https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/use-scim-to-provision-users-and-groups#update-group-remove-members):

```json
{
    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
    "Operations": [{
        "op": "Remove",
        "path": "members",
        "value": [{
            "$ref": null,
            "value": "f648f8d5ea4e4cd38e9c"
        }]
    }]
}
```

...in a generic way:

* The `$ref` entry is always just ignored
* When the `path` matches a SCIM resource attribute that's an array, then if `value` is an array, Scimitar will iterate over the resource's array entries an the value's array entries, matching the objects within.
  - Every key in the `remove` operation must be present in the resource array entry with a matching value, coerced to strings for comparison, but **case-sensitive** in order for removal to occur.
  - If the `value` entries are in fact simple types (e.g. integers or strings) instead of an object, *and* if the resource's corresponding array has simple types, then those are compared directly - again, coerced to strings, but **case sensitive**.

Fairly extensive test coverage is included for this. Upon implementation, the only arising test failure in the existing suite was from a `remove` operation that had a stray `value` present due to copy-paste errors from prior tests for addition or replacement, which points to a _slight_ chance of a strange SCIM implementation specifying values that it _expects_ to be totally ignored (!) possibly now failing. That seems very unlikely but, were it to be encountered, the changes made in this PR could be constrained to _just_ working for Groups and the `member` path. In the mean time, the more permissive and generic removal matching approach seems more useful and more likely to have broad compatibility.

Finally, there's a [probable documentation error in a Salesforce SCIM document](https://help.salesforce.com/s/articleView?id=sf.identity_scim_manage_groups.htm&type=5) which includes the `members` entry both in `path` and in `value`:

```json
{
  "schemas": [
    "urn:ietf:params:scim:api:messages:2.0:PatchOp"
  ],
  "Operations": [
    {
      "op": "remove",
      "path": "members",
      "value": {
        "members": [
          {
            "value": "<user_id>"
          }
        ]
      }
    }
  ]
}
```

...but since this _might_ be something a Salesforce SCIM API calling system actually does, it's handled as a specific special case. This is _not_ done generically; it'll only be applied on a path of exactly `members` and where `value` contains a _single_ top level key of, also, `members`.