### PR TITLE
Handle CONTENT_TYPE header containing charset correctly

### DIFF
--- a/app/controllers/scimitar/application_controller.rb
+++ b/app/controllers/scimitar/application_controller.rb
@@ -98,10 +98,10 @@ module Scimitar
       def require_scim
         scim_mime_type = Mime::Type.lookup_by_extension(:scim).to_s
 
-        if request.content_type.nil?
+        if request.media_type.nil?
           request.format = :scim
           request.headers['CONTENT_TYPE'] = scim_mime_type
-        elsif request.content_type&.downcase == scim_mime_type
+        elsif request.media_type.downcase == scim_mime_type
           request.format = :scim
         elsif request.format == :scim
           request.headers['CONTENT_TYPE'] = scim_mime_type

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -38,6 +38,16 @@ RSpec.describe Scimitar::ApplicationController do
       expect(parsed_body['request']['content_type']).to eql('application/scim+json')
     end
 
+    it 'translates Content-Type with charset to Rails request format' do
+      get '/CustomRequestVerifiers', headers: { 'CONTENT_TYPE' => 'application/scim+json; charset=utf-8' }
+
+      expect(response).to have_http_status(:ok)
+      parsed_body = JSON.parse(response.body)
+      expect(parsed_body['request']['is_scim'     ]).to eql(true)
+      expect(parsed_body['request']['format'      ]).to eql('application/scim+json')
+      expect(parsed_body['request']['content_type']).to eql('application/scim+json; charset=utf-8')
+    end
+
     it 'translates Rails request format to header' do
       get '/CustomRequestVerifiers', params: { format: :scim }
 


### PR DESCRIPTION
We encountered a problem using Microsoft Azure AD and traced it down to Microsoft sending `application/scim+json; charset=utf-8` in the `CONTENT_TYPE` header when calling `POST /Users`.

Since the CONTENT_TYPE header can contain more than just the Mime-Type scimitar should use `start_with?` instead of `==`. This PR changes that.

PS: I'm not sure if stripping the charset away from the `CONTENT_TPYE` header is wise. I just added that because the tests looked "more correct" to me first sight. If you know more or have objections just drop me a line.