### PR TITLE
Backport v2.4.2 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.2 (2023-03-21)
+
+* Back-ports fix in [#51](https://github.com/RIPAGlobal/scimitar/pull/51) from v2.4.1. Thanks to `@Flixt` for the contribution.
+
 # 1.5.1 (2023-03-20)
 
 * Back-ports features from v2.3.1 (addressing https://github.com/RIPAGlobal/scimitar/issues/48 by incorporating https://github.com/RIPAGlobal/scimitar/issues/49 into https://github.com/RIPAGlobal/scimitar/issues/50), for Rails 6 users.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    scimitar (1.5.1)
+    scimitar (1.5.2)
       rails (~> 6.0)
 
 GEM

--- a/app/controllers/scimitar/application_controller.rb
+++ b/app/controllers/scimitar/application_controller.rb
@@ -99,10 +99,10 @@ module Scimitar
       def require_scim
         scim_mime_type = Mime::Type.lookup_by_extension(:scim).to_s
 
-        if request.content_type.nil?
+        if request.media_type.nil? || request.media_type.empty?
           request.format = :scim
           request.headers['CONTENT_TYPE'] = scim_mime_type
-        elsif request.content_type&.downcase == scim_mime_type
+        elsif request.media_type.downcase == scim_mime_type
           request.format = :scim
         elsif request.format == :scim
           request.headers['CONTENT_TYPE'] = scim_mime_type

--- a/lib/scimitar/version.rb
+++ b/lib/scimitar/version.rb
@@ -3,11 +3,11 @@ module Scimitar
   # Gem version. If this changes, be sure to re-run "bundle install" or
   # "bundle update".
   #
-  VERSION = '1.5.1'
+  VERSION = '1.5.2'
 
   # Date for VERSION. If this changes, be sure to re-run "bundle install"
   # or "bundle update".
   #
-  DATE = '2023-03-20'
+  DATE = '2023-03-21'
 
 end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe Scimitar::ApplicationController do
       expect(parsed_body['request']['content_type']).to eql('application/scim+json')
     end
 
+    it 'translates Content-Type with charset to Rails request format' do
+      get '/CustomRequestVerifiers', headers: { 'CONTENT_TYPE' => 'application/scim+json; charset=utf-8' }
+
+      expect(response).to have_http_status(:ok)
+      parsed_body = JSON.parse(response.body)
+      expect(parsed_body['request']['is_scim'     ]).to eql(true)
+      expect(parsed_body['request']['format'      ]).to eql('application/scim+json')
+      expect(parsed_body['request']['content_type']).to eql('application/scim+json; charset=utf-8')
+    end
+
     it 'translates Rails request format to header' do
       get '/CustomRequestVerifiers', params: { format: :scim }
 


### PR DESCRIPTION
Backport v2.4.2 features - see #51, noting the addition of a check for an empty media type shown up by tests.