### PR TITLE
Fix warning messages for Rails 6 and Zeitwerk

### DIFF
--- a/config/initializers/scimitar.rb
+++ b/config/initializers/scimitar.rb
@@ -2,6 +2,7 @@
 #
 # For supporting information and rationale, please see README.md.
 
+Rails.application.config.to_prepare do
 # =============================================================================
 # SERVICE PROVIDER CONFIGURATION
 # =============================================================================
@@ -100,3 +101,4 @@ Scimitar.engine_configuration = Scimitar::EngineConfiguration.new({
   #
   #     optional_value_fields_required: false
 })
+end


### PR DESCRIPTION
```
[Sessions] Sessions won't be captured without a valid release
DEPRECATION WARNING: Initialization autoloaded the constants Scimitar::ServiceProviderConfiguration, Scimitar::Supportable, Scimitar::Filter, Scimitar::Meta, Scimitar::AuthenticationScheme, and Scimitar::EngineConfiguration.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload Scimitar::ServiceProviderConfiguration, for example,
the expected changes won't be reflected in that stale Class object.

These autoloaded constants have been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
```