### PR TITLE
Allow writable complex types in extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,43 @@ Whatever you provide in the `::id` method in your extension class will be used a
 }
 ```
 
-Resource extensions can provide any fields you choose, under any ID/URN you choose, to either RFC-described resources or entirely custom SCIM resources. They can also have Complex attributes such as phone numbers and groups. There are no hard-coded assumptions or other "magic" that might require you to only extend RFC-described resources with RFC-described extensions. Of course, if you use custom resources or custom extensions that are not described by the SCIM RFCs, then the SCIM API you provide may only work with custom-written API callers that are aware of your bespoke resources and/or extensions.
+Resource extensions can provide any fields you choose, under any ID/URN you choose, to either RFC-described resources or entirely custom SCIM resources. There are no hard-coded assumptions or other "magic" that might require you to only extend RFC-described resources with RFC-described extensions. Of course, if you use custom resources or custom extensions that are not described by the SCIM RFCs, then the SCIM API you provide may only work with custom-written API callers that are aware of your bespoke resources and/or extensions.
+
+Extensions can also contain complex attributes such as groups. For instance, if you want the ability to write to groups from the User resource perspective (since 'groups' collection in a SCIM User resource is read-only), you can add one attribute to your extension like this:
+
+```ruby
+Scimitar::Schema::Attribute.new(name: "userGroups", multiValued: true, complexType: Scimitar::ComplexTypes::ReferenceGroup, mutability: "writeOnly"),
+```
+
+Then map it in your `scim_attributes_map`:
+
+```ruby
+  userGroups: [
+    {
+      list: :groups,
+      find_with: ->(value) { Group.find(value["value"]) },
+      using: {
+        value:   :id,
+        display: :name
+      }
+    }
+  ]
+```
+
+And write to it like this:
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+  "Operations": [
+    {
+      "op": "replace",
+      "path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:userGroups",
+      "value": [{ "value": "1" }]
+    }
+  ]
+}
+```
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ Whatever you provide in the `::id` method in your extension class will be used a
 ```json
 {
   "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-  "Operations":[
+  "Operations": [
     {
       "op": "replace",
       "path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:organization",
@@ -468,9 +468,7 @@ Whatever you provide in the `::id` method in your extension class will be used a
 }
 ```
 
-Resource extensions can provide any fields you choose, under any ID/URN you choose, to either RFC-described resources or entirely custom SCIM resources. There are no hard-coded assumptions or other "magic" that might require you to only extend RFC-described resources with RFC-described extensions. Of course, if you use custom resources or custom extensions that are not described by the SCIM RFCs, then the SCIM API you provide may only work with custom-written API callers that are aware of your bespoke resources and/or extensions.
-
-
+Resource extensions can provide any fields you choose, under any ID/URN you choose, to either RFC-described resources or entirely custom SCIM resources. They can also have Complex attributes such as phone numbers and groups. There are no hard-coded assumptions or other "magic" that might require you to only extend RFC-described resources with RFC-described extensions. Of course, if you use custom resources or custom extensions that are not described by the SCIM RFCs, then the SCIM API you provide may only work with custom-written API callers that are aware of your bespoke resources and/or extensions.
 
 ## Security
 

--- a/app/models/scimitar/resources/base.rb
+++ b/app/models/scimitar/resources/base.rb
@@ -112,7 +112,7 @@ module Scimitar
       end
 
       def self.complex_scim_attributes
-        schema.scim_attributes.select(&:complexType).group_by(&:name)
+        schemas.flat_map(&:scim_attributes).select(&:complexType).group_by(&:name)
       end
 
       def complex_type_from_hash(scim_attribute, attr_value)

--- a/spec/apps/dummy/app/models/mock_user.rb
+++ b/spec/apps/dummy/app/models/mock_user.rb
@@ -17,6 +17,7 @@ class MockUser < ActiveRecord::Base
     work_phone_number
     organization
     department
+    mock_groups
   }
 
   has_and_belongs_to_many :mock_groups

--- a/spec/apps/dummy/app/models/mock_user.rb
+++ b/spec/apps/dummy/app/models/mock_user.rb
@@ -92,7 +92,17 @@ class MockUser < ActiveRecord::Base
       # "spec/apps/dummy/config/initializers/scimitar.rb".
       #
       organization: :organization,
-      department:   :department
+      department:   :department,
+      userGroups: [
+        {
+          list:      :mock_groups,
+          find_with: ->(value) { MockGroup.find(value["value"]) },
+          using: {
+            value:   :id,
+            display: :display_name
+          }
+        }
+      ]
     }
   end
 

--- a/spec/models/scimitar/resources/base_spec.rb
+++ b/spec/models/scimitar/resources/base_spec.rb
@@ -267,7 +267,10 @@ RSpec.describe Scimitar::Resources::Base do
         end
 
         def self.scim_attributes
-          [ Scimitar::Schema::Attribute.new(name: 'relationship', type: 'string', required: true) ]
+          [
+            Scimitar::Schema::Attribute.new(name: 'relationship', type: 'string', required: true),
+            Scimitar::Schema::Attribute.new(name: "userGroups", multiValued: true, complexType: Scimitar::ComplexTypes::ReferenceGroup, mutability: "writeOnly")
+          ]
         end
       end
 
@@ -290,6 +293,12 @@ RSpec.describe Scimitar::Resources::Base do
         it 'allows setting extension attributes' do
           resource = resource_class.new('extension-id' => {relationship: 'GAGA'})
           expect(resource.relationship).to eql('GAGA')
+        end
+
+        it 'allows setting complex extension attributes' do
+          user_groups = [{ value: '123' }, { value: '456'}]
+          resource = resource_class.new('extension-id' => {userGroups: user_groups})
+          expect(resource.userGroups.map(&:value)).to eql(['123', '456'])
         end
       end # "context '#initialize' do"
 


### PR DESCRIPTION
My goal is to be able to add groups to users, the same way we can add users to groups. Since that's not allowed by the SCIM default User schema, I have an extension type like this:

```ruby
module Scim
  class UserExtension < Scimitar::Schema::Base
    def initialize(_options = {})
      super(
        name: "ExtendedUser",
        description: "Auth Service extension for a User",
        id: self.class.id,
        scim_attributes: self.class.scim_attributes
      )
    end

    def self.id
      "urn:ietf:params:scim:schemas:extension:authservice:2.0:User"
    end

    def self.scim_attributes
      [
        Scimitar::Schema::Attribute.new(name: "userGroups", multiValued: true, complexType: Scimitar::ComplexTypes::ReferenceGroup, mutability: "writeOnly"),
      ]
    end
  end
end
```

But I'm currently not able to use this type like this in my project:

```ruby
      it "creates a user with department listed in the groups" do
        department = create(:group, :department, name: "The best department")
        groups = {
          Scim::UserExtension.id => {
            userGroups: [{ value: department.group_number.to_s }]
          }
        }

        post(api_scim_users_path, params: user_params.deep_merge(groups).to_json, headers:)

        expect(response).to have_http_status(:created)
        expect(response.parsed_body.dig(Scim::UserExtension.id, "userGroups")).to eq([{ value: department.group_number.to_s, display: "The best department" }])
      end
```

Without this patch, this is what I get:

```json
  {
    "schemas": [
      "urn:ietf:params:scim:api:messages:2.0:Error"
    ],
    "detail": "Invalid resource: Usergroups has to follow the complexType format..",
    "status": "400",
    "scimType": "invalidValue"
  }
```

Because `[{ value: "123" }]` never gets cast to the complex type.

Ps.: this is the generated request in the above example:

```json
{
    "schema": [
      "urn:ietf:params:scim:schemas:core:2.0:User",
      "urn:ietf:params:scim:schemas:extension:authservice:2.0:User"
    ],
    "externalId": 12345,
    "userName": "jane.doe",
    "displayName": "Jane Doe",
    "name": {
      "familyName": "Doe",
      "givenName": "Jane",
      "formatted": "Jane Doe"
    },
    "urn:ietf:params:scim:schemas:extension:authservice:2.0:User": {
      "userGroups": [
        {
          "value": "1"
        }
      ]
    }
  }
```