### PR TITLE
Allow complex queries with table joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ gem 'scimitar', '~> 2.0'
 
 Scimitar uses [semantic versioning](https://semver.org) so you can be confident that patch and minor version updates for features, bug fixes and/or security patches will not break your application.
 
-
-
 ## Heritage
 
 Scimitar borrows heavily - to the point of cut-and-paste - from:
@@ -51,8 +49,6 @@ Scimitar borrows heavily - to the point of cut-and-paste - from:
 * [SCIM Query Filter Parser](https://github.com/ingydotnet/scim-query-filter-parser-rb) for advanced filter handling.
 
 All three are provided under the MIT license. Scimitar is too.
-
-
 
 ## Usage
 
@@ -199,9 +195,11 @@ class User < ActiveRecord::Base
 
   def self.scim_queryable_attributes
     return {
-      givenName:  :first_name,
-      familyName: :last_name,
-      emails:     :work_email_address,
+      givenName:        { column: :first_name },
+      familyName:       { column: :last_name },
+      emails:           { column: :work_email_address },
+      "groups":         { column: MockGroup.arel_table[:id] },
+      "groups.value":   { column: MockGroup.arel_table[:id] },
     }
   end
 
@@ -222,6 +220,8 @@ end
 ```
 
 ### Controllers
+
+#### ActiveRecord
 
 If you use ActiveRecord, your controllers can potentially be extremely simple by subclassing [`Scimitar::ActiveRecordBackedResourcesController`](https://www.rubydoc.info/gems/scimitar/Scimitar/ActiveRecordBackedResourcesController) - at a minimum:
 
@@ -246,6 +246,26 @@ end
 ```
 
 All data-layer actions are taken via `#find` or `#save!`, with exceptions such as `ActiveRecord::RecordNotFound`, `ActiveRecord::RecordInvalid` or generalised SCIM exceptions handled by various superclasses. For a real Rails example of this, see the [test suite's controllers](https://github.com/RIPAGlobal/scimitar/tree/main/spec/apps/dummy/app/controllers) which are invoked via its [routing declarations](https://github.com/RIPAGlobal/scimitar/blob/main/spec/apps/dummy/config/routes.rb).
+
+#### Queries & Optimizations
+
+The scope can be optimized to eager load the data exposed by the SCIM interface, i.e.:
+
+```ruby
+      def storage_scope
+        User.eager_load(:groups)
+      end
+```
+
+In cases where you have references to related columns in your `scim_queryable_attributes`, your `storage_scope` must join the relation:
+
+```ruby
+      def storage_scope
+        User.left_join(:groups)
+      end
+```
+
+#### Other source types
 
 If you do _not_ use ActiveRecord to store data, or if you have very esoteric read-write requirements, you can subclass [`Scimigar::ResourcesController`](https://www.rubydoc.info/gems/scimitar/Scimitar/ResourcesController) in a manner similar to this:
 
@@ -543,8 +563,6 @@ If you believe choices made in this section may be incorrect, please [create a G
 * The `PATCH` mechanism is supported, but where filters are included, only a single "attribute eq value" is permitted - no other operators or combinations. For example, a work e-mail address's value could be replaced by a PATCH patch of `emails[type eq "work"].value`. For in-path filters such as this, other operators such as `ne` are not supported; combinations with "and"/"or" are not supported; negation with "not" is not supported.
 
 If you would like to see something listed in the session implemented, please [create a GitHub issue](https://github.com/RIPAGlobal/scimitar/issues/new) asking for it to be implemented, or if possible, implement the feature and send a Pull Request.
-
-
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ gem 'scimitar', '~> 2.0'
 
 Scimitar uses [semantic versioning](https://semver.org) so you can be confident that patch and minor version updates for features, bug fixes and/or security patches will not break your application.
 
+
+
 ## Heritage
 
 Scimitar borrows heavily - to the point of cut-and-paste - from:
@@ -49,6 +51,8 @@ Scimitar borrows heavily - to the point of cut-and-paste - from:
 * [SCIM Query Filter Parser](https://github.com/ingydotnet/scim-query-filter-parser-rb) for advanced filter handling.
 
 All three are provided under the MIT license. Scimitar is too.
+
+
 
 ## Usage
 
@@ -563,6 +567,8 @@ If you believe choices made in this section may be incorrect, please [create a G
 * The `PATCH` mechanism is supported, but where filters are included, only a single "attribute eq value" is permitted - no other operators or combinations. For example, a work e-mail address's value could be replaced by a PATCH patch of `emails[type eq "work"].value`. For in-path filters such as this, other operators such as `ne` are not supported; combinations with "and"/"or" are not supported; negation with "not" is not supported.
 
 If you would like to see something listed in the session implemented, please [create a GitHub issue](https://github.com/RIPAGlobal/scimitar/issues/new) asking for it to be implemented, or if possible, implement the feature and send a Pull Request.
+
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -197,13 +197,18 @@ class User < ActiveRecord::Base
     return nil
   end
 
+  # The attributes in the SCIM section below include a reference to this
+  # hypothesised 'Group' model, same as the HABTM relationship above.
+  # In this case, in order to filter by `groups.value` or `groups`, the
+  # SCIM controller `storage_scope` has to introduce a join with Groups.
+  #
   def self.scim_queryable_attributes
     return {
       givenName:        { column: :first_name },
       familyName:       { column: :last_name },
       emails:           { column: :work_email_address },
-      "groups":         { column: MockGroup.arel_table[:id] },
-      "groups.value":   { column: MockGroup.arel_table[:id] },
+      groups:           { column: Group.arel_table[:id] },
+      "groups.value" => { column: Group.arel_table[:id] },
     }
   end
 
@@ -482,7 +487,7 @@ Whatever you provide in the `::id` method in your extension class will be used a
 ```json
 {
   "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-  "Operations":[
+  "Operations": [
     {
       "op": "replace",
       "path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:organization",

--- a/app/models/scimitar/resources/mixin.rb
+++ b/app/models/scimitar/resources/mixin.rb
@@ -220,13 +220,7 @@ module Scimitar
     # allow for different client searching "styles", given ambiguities in RFC
     # 7644 filter examples).
     #
-    # Each value is a Hash with Symbol keys ':column', naming just one simple
-    # column for a mapping; ':columns', with an Array of column names that you
-    # want to map using 'OR' for a single search on the corresponding SCIM
-    # attribute; or ':ignore' with value 'true', which means that a fitler on
-    # the matching attribute is ignored rather than resulting in an "invalid
-    # filter" exception - beware possibilities for surprised clients getting a
-    # broader result set than expected. Example:
+    # Each value is a hash of queryable SCIM attribute options:
     #
     #     def self.scim_queryable_attributes
     #       return {
@@ -234,9 +228,23 @@ module Scimitar
     #         'name.familyName' => { column: :last_name  },
     #         'emails'          => { columns: [ :work_email_address, :home_email_address ] },
     #         'emails.value'    => { columns: [ :work_email_address, :home_email_address ] },
-    #         'emails.type'     => { ignore: true }
+    #         'emails.type'     => { ignore: true },
+    #         'groups.value'    => { column: Group.arel_table[:id] }
     #       }
     #     end
+    #
+    # === Queryable SCIM attribute options
+    #
+    # Column references can be either a Symbol representing a column within
+    # the resource model table, or an `Arel::Attribute` (i.e.: `MyModel.arel_table[:my_column]`).
+    #
+    # `:column`, with just one simple column for a mapping
+    # `:columns`, an Array of columns that you want to map using 'OR' for a
+    #             single search on the corresponding SCIM
+    # `:ignore`, when set to `true`, the matching attribute is ignored rather
+    #            than resulting in an "invalid filter" exception - beware
+    #            possibilities for surprised clients getting a broader result
+    #            set than expected. Example:
     #
     # Filtering is currently limited and searching within e.g. arrays of data
     # is not supported; only simple top-level keys can be mapped.

--- a/spec/apps/dummy/app/models/mock_user.rb
+++ b/spec/apps/dummy/app/models/mock_user.rb
@@ -107,6 +107,8 @@ class MockUser < ActiveRecord::Base
       'meta.lastModified' => { column: :updated_at },
       'name.givenName'    => { column: :first_name },
       'name.familyName'   => { column: :last_name  },
+      'groups'            => { column: MockGroup.arel_table[:id] },
+      'groups.value'      => { column: MockGroup.arel_table[:id] },
       'emails'            => { columns: [ :work_email_address, :home_email_address ] },
       'emails.value'      => { columns: [ :work_email_address, :home_email_address ] },
       'emails.type'       => { ignore: true } # We can't filter on that; it'll just search all e-mails

--- a/spec/models/scimitar/lists/query_parser_spec.rb
+++ b/spec/models/scimitar/lists/query_parser_spec.rb
@@ -481,6 +481,66 @@ RSpec.describe Scimitar::Lists::QueryParser do
       end
     end # "context 'when instructed to ignore an attribute' do"
 
+    context 'when an arel column is mapped' do
+      let(:scope_with_groups) { MockUser.left_joins(:mock_groups) }
+
+      context 'with binary operators' do
+        it 'reads across all using OR' do
+          @instance.parse('groups eq "12345"')
+          query = @instance.to_activerecord_query(scope_with_groups)
+
+          expect(query.to_sql).to eql(<<~SQL.squish)
+            SELECT "mock_users".*
+            FROM "mock_users"
+              LEFT OUTER JOIN "mock_groups_users" ON "mock_groups_users"."mock_user_id" = "mock_users"."primary_key"
+              LEFT OUTER JOIN "mock_groups" ON "mock_groups"."id" = "mock_groups_users"."mock_group_id"
+            WHERE "mock_groups"."id" ILIKE 12345
+          SQL
+        end
+
+        it 'works with other query elements using correct precedence' do
+          @instance.parse('groups eq "12345" and emails eq "any@test.com"')
+          query = @instance.to_activerecord_query(scope_with_groups)
+
+          expect(query.to_sql).to eql(<<~SQL.squish)
+            SELECT "mock_users".*
+            FROM "mock_users"
+              LEFT OUTER JOIN "mock_groups_users" ON "mock_groups_users"."mock_user_id" = "mock_users"."primary_key"
+              LEFT OUTER JOIN "mock_groups" ON "mock_groups"."id" = "mock_groups_users"."mock_group_id"
+            WHERE "mock_groups"."id" ILIKE 12345 AND ("mock_users"."work_email_address" ILIKE 'any@test.com' OR "mock_users"."home_email_address" ILIKE 'any@test.com')
+          SQL
+        end
+      end # "context 'with binary operators' do"
+
+      context 'with unary operators' do
+        it 'reads across all using OR' do
+          @instance.parse('groups pr')
+          query = @instance.to_activerecord_query(scope_with_groups)
+
+          expect(query.to_sql).to eql(<<~SQL.squish)
+            SELECT "mock_users".*
+            FROM "mock_users"
+              LEFT OUTER JOIN "mock_groups_users" ON "mock_groups_users"."mock_user_id" = "mock_users"."primary_key"
+              LEFT OUTER JOIN "mock_groups" ON "mock_groups"."id" = "mock_groups_users"."mock_group_id"
+            WHERE ("mock_groups"."id" != NULL AND "mock_groups"."id" IS NOT NULL)
+          SQL
+        end
+
+        it 'works with other query elements using correct precedence' do
+          @instance.parse('name.familyName eq "John" and groups pr')
+          query = @instance.to_activerecord_query(scope_with_groups)
+
+          expect(query.to_sql).to eql(<<~SQL.squish)
+            SELECT "mock_users".*
+            FROM "mock_users"
+              LEFT OUTER JOIN "mock_groups_users" ON "mock_groups_users"."mock_user_id" = "mock_users"."primary_key"
+              LEFT OUTER JOIN "mock_groups" ON "mock_groups"."id" = "mock_groups_users"."mock_group_id"
+            WHERE "mock_users"."last_name" ILIKE 'John' AND ("mock_groups"."id" != NULL AND "mock_groups"."id" IS NOT NULL)
+          SQL
+        end
+      end # "context 'with unary operators' do
+    end # "context 'when an arel column is mapped' do"
+
     context 'with complex cases' do
       context 'using AND' do
         it 'generates expected SQL' do


### PR DESCRIPTION
Allow using external columns for complex joins. In the bellow example we're able to query the user membership within a group:

```ruby
  class User < ApplicationRecord
    has_and_belongs_to_many :groups

    def self.scim_queryable_attributes
      return {
        'groups'       => { column: Group.arel_table[:id] },
        'groups.value' => { column: Group.arel_table[:id] },
      }
    end
  end
```

Then:

```ruby
  class UsersController < Scimitar::ActiveRecordBackedResourcesController
    def storage_class
      ::User
    end

    def storage_scope
      ::User.left_joins(:groups)
    end
  end
```
