### PR TITLE
Backwards-compatible modifications to support #54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.3 (2023-06-20)
+
+* Fix warning messages for Rails 6 and Zeitwerk. Thanks to `@sobrinho` for the contribution.
+
 # 1.5.2 (2023-03-21)
 
 * Back-ports fix in [#51](https://github.com/RIPAGlobal/scimitar/pull/51) from v2.4.1. Thanks to `@Flixt` for the contribution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.5.3 (2023-06-20)
+# 1.5.3 (2023-09-16)
 
 * Fix warning messages for Rails 6 and Zeitwerk. Thanks to `@sobrinho` for the contribution.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    scimitar (1.5.2)
+    scimitar (1.5.3)
       rails (~> 6.0)
 
 GEM

--- a/app/models/scimitar/engine_configuration.rb
+++ b/app/models/scimitar/engine_configuration.rb
@@ -7,13 +7,17 @@ module Scimitar
   class EngineConfiguration
     include ActiveModel::Model
 
-    attr_accessor :basic_authenticator,
-                  :token_authenticator,
-                  :application_controller_mixin,
-                  :exception_reporter,
-                  :optional_value_fields_required
+    attr_accessor(
+      :uses_defaults,
+      :basic_authenticator,
+      :token_authenticator,
+      :application_controller_mixin,
+      :exception_reporter,
+      :optional_value_fields_required,
+    )
 
     def initialize(attributes = {})
+      @uses_defaults = attributes.empty?
 
       # Set defaults that may be overridden by the initializer.
       #

--- a/app/models/scimitar/service_provider_configuration.rb
+++ b/app/models/scimitar/service_provider_configuration.rb
@@ -9,11 +9,22 @@ module Scimitar
   class ServiceProviderConfiguration
     include ActiveModel::Model
 
-    attr_accessor :patch, :bulk, :filter, :changePassword,
-      :sort, :etag, :authenticationSchemes,
-      :schemas, :meta
+    attr_accessor(
+      :uses_defaults,
+      :patch,
+      :bulk,
+      :filter,
+      :changePassword,
+      :sort,
+      :etag,
+      :authenticationSchemes,
+      :schemas,
+      :meta,
+    )
 
     def initialize(attributes = {})
+      @uses_defaults = attributes.empty?
+
       defaults = {
         bulk:           Supportable.unsupported,
         changePassword: Supportable.unsupported,

--- a/config/initializers/scimitar.rb
+++ b/config/initializers/scimitar.rb
@@ -2,103 +2,105 @@
 #
 # For supporting information and rationale, please see README.md.
 
-Rails.application.config.to_prepare do
-# =============================================================================
-# SERVICE PROVIDER CONFIGURATION
-# =============================================================================
-#
-# This is a Ruby abstraction over a SCIM entity that declares the capabilities
-# supported by a particular implementation.
-#
-# Typically this is used to declare parts of the standard unsupported, if you
-# don't need them and don't want to provide subclass support.
-#
-Scimitar.service_provider_configuration = Scimitar::ServiceProviderConfiguration.new({
+Rails.application.config.to_prepare do # (required for >= Rails 7 / Zeitwerk)
 
-  # See https://tools.ietf.org/html/rfc7643#section-8.5 for properties.
+  # ===========================================================================
+  # SERVICE PROVIDER CONFIGURATION
+  # ===========================================================================
   #
-  # See Gem source file 'app/models/scimitar/service_provider_configuration.rb'
-  # for defaults. Define Hash keys here that override defaults; e.g. to declare
-  # that filters are not supported so that calling clients shouldn't use them:
+  # This is a Ruby abstraction over a SCIM entity that declares the
+  # capabilities supported by a particular implementation.
   #
-  #   filter: Scimitar::Supported.unsupported
+  # Typically this is used to declare parts of the standard unsupported, if you
+  # don't need them and don't want to provide subclass support.
+  #
+  Scimitar.service_provider_configuration = Scimitar::ServiceProviderConfiguration.new({
 
-})
+    # See https://tools.ietf.org/html/rfc7643#section-8.5 for properties.
+    #
+    # See Gem file 'app/models/scimitar/service_provider_configuration.rb'
+    # for defaults. Define Hash keys here that override defaults; e.g. to
+    # declare that filters are not supported so that calling clients shouldn't
+    # use them:
+    #
+    #   filter: Scimitar::Supported.unsupported
 
-# =============================================================================
-# ENGINE CONFIGURATION
-# =============================================================================
-#
-# This is where you provide callbacks for things like authorisation or mixins
-# that get included into all Scimitar-derived controllers (for things like
-# before-actions that apply to all Scimitar controller-based routes).
-#
-Scimitar.engine_configuration = Scimitar::EngineConfiguration.new({
+  })
 
-  # If you have filters you want to run for any Scimitar action/route, you can
-  # define them here. For example, you might use a before-action to set up some
-  # multi-tenancy related state, or skip Rails CSRF token verification/
+  # ===========================================================================
+  # ENGINE CONFIGURATION
+  # ===========================================================================
   #
-  # For example:
+  # This is where you provide callbacks for things like authorisation or mixins
+  # that get included into all Scimitar-derived controllers (for things like
+  # before-actions that apply to all Scimitar controller-based routes).
   #
-  #     application_controller_mixin: Module.new do
-  #       def self.included(base)
-  #         base.class_eval do
-  #
-  #           # Anything here is written just as you'd write it at the top of
-  #           # one of your controller classes, but it gets included in all
-  #           # Scimitar classes too.
-  #
-  #           skip_before_action    :verify_authenticity_token
-  #           prepend_before_action :setup_some_kind_of_multi_tenancy_data
-  #         end
-  #       end
-  #     end, # ...other configuration entries might follow...
+  Scimitar.engine_configuration = Scimitar::EngineConfiguration.new({
 
-  # If you want to support username/password authentication:
-  #
-  #     basic_authenticator: Proc.new do | username, password |
-  #       # Check username/password and return 'true' if valid, else 'false'.
-  #     end, # ...other configuration entries might follow...
-  #
-  # The 'username' and 'password' parameters come from Rails:
-  #
-  #   https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Basic.html
-  #   https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Basic/ControllerMethods.html#method-i-authenticate_with_http_basic
+    # If you have filters you want to run for any Scimitar action/route, you
+    # can define them here. For example, you might use a before-action to set
+    # up some multi-tenancy related state, or skip Rails CSRF token
+    # verification. For example:
+    #
+    #     application_controller_mixin: Module.new do
+    #       def self.included(base)
+    #         base.class_eval do
+    #
+    #           # Anything here is written just as you'd write it at the top of
+    #           # one of your controller classes, but it gets included in all
+    #           # Scimitar classes too.
+    #
+    #           skip_before_action    :verify_authenticity_token
+    #           prepend_before_action :setup_some_kind_of_multi_tenancy_data
+    #         end
+    #       end
+    #     end, # ...other configuration entries might follow...
 
-  # If you want to support HTTP bearer token (OAuth-style) authentication:
-  #
-  #     token_authenticator: Proc.new do | token, options |
-  #       # Check token and return 'true' if valid, else 'false'.
-  #     end, # ...other configuration entries might follow...
-  #
-  # The 'token' and 'options' parameters come from Rails:
-  #
-  #   https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token.html
-  #   https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token/ControllerMethods.html#method-i-authenticate_with_http_token
-  #
-  # Note that both basic and token authentication can be declared, with the
-  # parameters in the inbound HTTP request determining which is invoked.
+    # If you want to support username/password authentication:
+    #
+    #     basic_authenticator: Proc.new do | username, password |
+    #       # Check username/password and return 'true' if valid, else 'false'.
+    #     end, # ...other configuration entries might follow...
+    #
+    # The 'username' and 'password' parameters come from Rails:
+    #
+    #   https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Basic.html
+    #   https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Basic/ControllerMethods.html#method-i-authenticate_with_http_basic
 
-  # Scimitar rescues certain error cases and exceptions, in order to return a
-  # JSON response to the API caller. If you want exceptions to also be
-  # reported to a third party system such as sentry.io or raygun.com, you can
-  # configure a Proc to do so. It is passed a Ruby exception subclass object.
-  # For example, a minimal sentry.io reporter might do this:
-  #
-  #     exception_reporter: Proc.new do | exception |
-  #       Sentry.capture_exception(exception)
-  #     end
-  #
-  # You will still need to configure your reporting system according to its
-  # documentation (e.g. via a Rails "config/initializers/<foo>.rb" file).
+    # If you want to support HTTP bearer token (OAuth-style) authentication:
+    #
+    #     token_authenticator: Proc.new do | token, options |
+    #       # Check token and return 'true' if valid, else 'false'.
+    #     end, # ...other configuration entries might follow...
+    #
+    # The 'token' and 'options' parameters come from Rails:
+    #
+    #   https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token.html
+    #   https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token/ControllerMethods.html#method-i-authenticate_with_http_token
+    #
+    # Note that both basic and token authentication can be declared, with the
+    # parameters in the inbound HTTP request determining which is invoked.
 
-  # Scimilar treats "VDTP" (Value, Display, Type, Primary) attribute values,
-  # used for e.g. e-mail addresses or phone numbers, as required by default.
-  # If you encounter a service which calls these with e.g. "null" value data,
-  # you can configure all values to be optional. You'll need to deal with
-  # whatever that means for you receiving system in your model code.
-  #
-  #     optional_value_fields_required: false
-})
+    # Scimitar rescues certain error cases and exceptions, in order to return a
+    # JSON response to the API caller. If you want exceptions to also be
+    # reported to a third party system such as sentry.io or raygun.com, you can
+    # configure a Proc to do so. It is passed a Ruby exception subclass object.
+    # For example, a minimal sentry.io reporter might do this:
+    #
+    #     exception_reporter: Proc.new do | exception |
+    #       Sentry.capture_exception(exception)
+    #     end
+    #
+    # You will still need to configure your reporting system according to its
+    # documentation (e.g. via a Rails "config/initializers/<foo>.rb" file).
+
+    # Scimilar treats "VDTP" (Value, Display, Type, Primary) attribute values,
+    # used for e.g. e-mail addresses or phone numbers, as required by default.
+    # If you encounter a service which calls these with e.g. "null" value data,
+    # you can configure all values to be optional. You'll need to deal with
+    # whatever that means for you receiving system in your model code.
+    #
+    #     optional_value_fields_required: false
+  })
+
 end

--- a/lib/scimitar.rb
+++ b/lib/scimitar.rb
@@ -4,7 +4,9 @@ require 'scimitar/engine'
 
 module Scimitar
   def self.service_provider_configuration=(custom_configuration)
-    @service_provider_configuration = custom_configuration
+    if @service_provider_configuration.nil? || ! custom_configuration.uses_defaults
+      @service_provider_configuration = custom_configuration
+    end
   end
 
   def self.service_provider_configuration(location:)
@@ -14,11 +16,25 @@ module Scimitar
   end
 
   def self.engine_configuration=(custom_configuration)
-    @engine_configuration = custom_configuration
+    if @engine_configuration.nil? || ! custom_configuration.uses_defaults
+      @engine_configuration = custom_configuration
+    end
   end
 
   def self.engine_configuration
     @engine_configuration ||= EngineConfiguration.new
     @engine_configuration
+  end
+
+  # Set in a "Rails.application.config.to_prepare" block by Scimitar itself to
+  # establish default values. Older Scimitar client applications might not use
+  # that wrapper; we don't want to overwrite settings they configured, but we
+  # *do* want to let them overwrite the defaults. Thus, '||=" is used here but
+  # not in ::service_provider_configuration=.
+  #
+  # Client applications should not call this method themselves.
+  #
+  def self.default_service_provider_configuration(default_configuration)
+    @service_provider_configuration ||= custom_configuration
   end
 end

--- a/lib/scimitar/version.rb
+++ b/lib/scimitar/version.rb
@@ -3,11 +3,11 @@ module Scimitar
   # Gem version. If this changes, be sure to re-run "bundle install" or
   # "bundle update".
   #
-  VERSION = '1.5.2'
+  VERSION = '1.5.3'
 
   # Date for VERSION. If this changes, be sure to re-run "bundle install"
   # or "bundle update".
   #
-  DATE = '2023-03-21'
+  DATE = '2023-06-20'
 
 end

--- a/lib/scimitar/version.rb
+++ b/lib/scimitar/version.rb
@@ -8,6 +8,6 @@ module Scimitar
   # Date for VERSION. If this changes, be sure to re-run "bundle install"
   # or "bundle update".
   #
-  DATE = '2023-06-20'
+  DATE = '2023-09-16'
 
 end

--- a/spec/apps/dummy/config/initializers/scimitar.rb
+++ b/spec/apps/dummy/config/initializers/scimitar.rb
@@ -9,6 +9,14 @@
 #
 # All related schema tests are written with this in mind.
 #
+# Further, https://github.com/RIPAGlobal/scimitar/pull/54 fixed warning
+# messages in a way that worked on Rails 6+ but backported for V1, it would
+# break existing working setups that didn't use the "to_prepare" wrapper since
+# that would mean their own configuration got written *first* but then
+# *overwritten* by the default "to_prepare" block in Scimitar itself, since
+# that runs later. The file below does *not* use "to_prepare" in order to test
+# the workaround that was produced; it should work on all Ruby versions as-is.
+#
 Scimitar.engine_configuration = Scimitar::EngineConfiguration.new({
 
   application_controller_mixin: Module.new do

--- a/spec/apps/dummy/config/initializers/scimitar.rb
+++ b/spec/apps/dummy/config/initializers/scimitar.rb
@@ -10,12 +10,12 @@
 # All related schema tests are written with this in mind.
 #
 # Further, https://github.com/RIPAGlobal/scimitar/pull/54 fixed warning
-# messages in a way that worked on Rails 6+ but backported for V1, it would
-# break existing working setups that didn't use the "to_prepare" wrapper since
-# that would mean their own configuration got written *first* but then
-# *overwritten* by the default "to_prepare" block in Scimitar itself, since
-# that runs later. The file below does *not* use "to_prepare" in order to test
-# the workaround that was produced; it should work on all Ruby versions as-is.
+# messages in a way that worked on Rails 6+ but, for V1 Scimitar, it would
+# break existing working setups that didn't use the +to_prepare+ wrapper. Their
+# application configuration would be written *first* but then *overwritten* by
+# the default +to_prepare+ block in Scimitar itself, since that runs later. The
+# file below does *not* use +to_prepare+ in order to test the workaround that
+# was produced; it should work on all Ruby versions as-is.
 #
 Scimitar.engine_configuration = Scimitar::EngineConfiguration.new({
 

--- a/spec/controllers/scimitar/application_controller_spec.rb
+++ b/spec/controllers/scimitar/application_controller_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Scimitar::ApplicationController do
       request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('A', 'B')
 
       get :index, params: { format: :scim }
+
       expect(response).to be_ok
       expect(JSON.parse(response.body)).to eql({ 'message' => 'cool, cool!' })
       expect(response.headers['WWW_AUTHENTICATE']).to eql('Basic')

--- a/spec/controllers/scimitar/application_controller_spec.rb
+++ b/spec/controllers/scimitar/application_controller_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Scimitar::ApplicationController do
       request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('A', 'B')
 
       get :index, params: { format: :scim }
-
       expect(response).to be_ok
       expect(JSON.parse(response.body)).to eql({ 'message' => 'cool, cool!' })
       expect(response.headers['WWW_AUTHENTICATE']).to eql('Basic')


### PR DESCRIPTION
Support #54 but with backwards compatibility. Applications that don't use `to_prepare` will no longer have their configuration updated by Scimitar's defaults via its own `to_prepare` block.