### PR TITLE
Comprehensible error when PatchOp is missing operations

### DIFF
--- a/app/models/scimitar/resources/mixin.rb
+++ b/app/models/scimitar/resources/mixin.rb
@@ -406,8 +406,11 @@ module Scimitar
         def from_scim_patch!(patch_hash:)
           frozen_ci_patch_hash = patch_hash.with_indifferent_case_insensitive_access().freeze()
           ci_scim_hash         = self.to_scim(location: '(unused)').as_json().with_indifferent_case_insensitive_access()
+          operations           = frozen_ci_patch_hash['operations']
 
-          frozen_ci_patch_hash['operations'].each do |operation|
+          raise Scimitar::InvalidSyntaxError.new("Missing PATCH \"operations\"") unless operations
+
+          operations.each do |operation|
             nature   = operation['op'   ]&.downcase
             path_str = operation['path' ]
             value    = operation['value']

--- a/spec/models/scimitar/resources/mixin_spec.rb
+++ b/spec/models/scimitar/resources/mixin_spec.rb
@@ -2685,6 +2685,14 @@ RSpec.describe Scimitar::Resources::Mixin do
       #
       context 'public interface' do
         shared_examples 'a patcher' do | force_upper_case: |
+          it 'gives the user a comprehensible error when operations are missing' do
+            patch = { 'schemas' => ['urn:ietf:params:scim:api:messages:2.0:PatchOp'] }
+
+            expect do
+              @instance.from_scim_patch!(patch_hash: patch)
+            end.to raise_error Scimitar::InvalidSyntaxError, "Missing PATCH \"operations\""
+          end
+
           it 'which updates simple values' do
             @instance.update!(username: 'foo')
 


### PR DESCRIPTION
Throws a comprehensible error when missing `operations` in a PatchOp
