### PR TITLE
Allow combined logical groups to generate working queries

### DIFF
--- a/app/models/scimitar/lists/query_parser.rb
+++ b/app/models/scimitar/lists/query_parser.rb
@@ -192,7 +192,7 @@ module Scimitar
 
             ast.push(self.start_group? ? self.parse_group() : self.pop())
 
-            unless ! ast.last.is_a?(String) || UNARY_OPERATORS.include?(ast.last.downcase)
+            if ast.last.is_a?(String) && !UNARY_OPERATORS.include?(ast.last.downcase) || ast.last.is_a?(Array)
               expect_op ^= true
             end
           end

--- a/spec/models/scimitar/lists/query_parser_spec.rb
+++ b/spec/models/scimitar/lists/query_parser_spec.rb
@@ -532,6 +532,13 @@ RSpec.describe Scimitar::Lists::QueryParser do
           expect(query.to_sql).to eql(%q{SELECT "mock_users".* FROM "mock_users" WHERE "mock_users"."first_name" ILIKE 'Jane' AND ("mock_users"."last_name" ILIKE '%avi%' OR "mock_users"."last_name" ILIKE '%ith')})
         end
 
+        it 'combined parentheses generates expected SQL' do
+          @instance.parse('(name.givenName eq "Jane" OR name.givenName eq "Jaden") and (name.familyName co "avi" or name.familyName ew "ith")')
+          query = @instance.to_activerecord_query(MockUser.all)
+
+          expect(query.to_sql).to eql(%q{SELECT "mock_users".* FROM "mock_users" WHERE ("mock_users"."first_name" ILIKE 'Jane' OR "mock_users"."first_name" ILIKE 'Jaden') AND ("mock_users"."last_name" ILIKE '%avi%' OR "mock_users"."last_name" ILIKE '%ith')})
+        end
+
         it 'finds expected items' do
           user_1 = MockUser.create(username: '1', first_name: 'Jane', last_name: 'Davis')   # Match
           user_2 = MockUser.create(username: '2', first_name: 'Jane', last_name: 'Smith')   # Match


### PR DESCRIPTION
Allow combined logical groups. I.e.:

```
filter=(name.givenName eq "Jane" OR name.givenName eq "Jaden") and (name.familyName co "avi" or name.familyName ew "ith")
```

Without this fix, the parser assumes it can't process a logical operation at the end of a group.

With this fix it produces the following SQL:

```sql
SELECT "mock_users".*
FROM "mock_users"
WHERE ("mock_users"."first_name" ILIKE 'Jane' OR "mock_users"."first_name" ILIKE 'Jaden')
    AND ("mock_users"."last_name" ILIKE '%avi%' OR "mock_users"."last_name" ILIKE '%ith')
```
