### PR TITLE
Allow specifying of nested values in dotpath notation for path-less replace operations

### DIFF
--- a/app/models/scimitar/resources/mixin.rb
+++ b/app/models/scimitar/resources/mixin.rb
@@ -952,7 +952,10 @@ module Scimitar
 
                 when 'replace'
                   if path_component == 'root'
-                    altering_hash[path_component].merge!(value)
+                    dot_pathed_value = value.inject({}) do |hash, (k, v)|
+                      hash.deep_merge!(::Scimitar::Support::Utilities.dot_path(k.split('.'), v))
+                    end
+                    altering_hash[path_component].deep_merge!(dot_pathed_value)
                   else
                     altering_hash[path_component] = value
                   end

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'rails'
+
+require_relative '../lib/scimitar'
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require 'irb'
+IRB.start(__FILE__)

--- a/lib/scimitar.rb
+++ b/lib/scimitar.rb
@@ -1,5 +1,6 @@
 require 'scimitar/version'
 require 'scimitar/support/hash_with_indifferent_case_insensitive_access'
+require 'scimitar/support/utilities'
 require 'scimitar/engine'
 
 module Scimitar

--- a/lib/scimitar/support/utilities.rb
+++ b/lib/scimitar/support/utilities.rb
@@ -1,0 +1,51 @@
+module Scimitar
+
+  # Namespace containing various chunks of Scimitar support code that don't
+  # logically fit into other areas.
+  #
+  module Support
+
+    # A namespace that contains various stand-alone utility methods which act
+    # as helpers for other parts of the code base, without risking namespace
+    # pollution by e.g. being part of a module loaded into a client class.
+    #
+    module Utilities
+
+      # Takes an array of components that usually come from a dotted path such
+      # as <tt>foo.bar.baz</tt>, along with a value that is found at the end of
+      # that path, then converts it into a nested Hash with each level of the
+      # Hash corresponding to a step along the path.
+      #
+      # This was written to help with edge case SCIM uses where (most often, at
+      # least) inbound calls use a dotted notation where nested values are more
+      # commonly accepted; converting to nesting makes it easier for subsequent
+      # processing code, which needs only handle nested Hash data.
+      #
+      # As an example, passing:
+      #
+      #     ['foo', 'bar', 'baz'], 'value'
+      #
+      # ...yields:
+      #
+      #     {'foo' => {'bar' => {'baz' => 'value'}}}
+      #
+      # Parameters:
+      #
+      # +array+:: Array containing path components, usually acquired from a
+      #           string with dot separators and a call to String#split.
+      #
+      # +value+:: The value found at the path indicated by +array+.
+      #
+      # If +array+ is empty, +value+ is returned directly, with no nesting
+      # Hash wrapping it.
+      #
+      def self.dot_path(array, value)
+        return value if array.empty?
+
+        {}.tap do | hash |
+          hash[array.shift()] = self.dot_path(array, value)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/scimitar/resources/mixin_spec.rb
+++ b/spec/models/scimitar/resources/mixin_spec.rb
@@ -2714,6 +2714,28 @@ RSpec.describe Scimitar::Resources::Mixin do
             expect(@instance.username).to eql('1234')
           end
 
+          it 'which updates nested values using root syntax' do
+            @instance.update!(first_name: 'Foo', last_name: 'Bar')
+
+            path = 'name.givenName'
+            path = path.upcase if force_upper_case
+
+            patch = {
+              'schemas'    => ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+              'Operations' => [
+                {
+                  'op'    => 'replace',
+                  'value' => {
+                    path => 'Baz'
+                  }
+                }
+              ]
+            }
+
+            @instance.from_scim_patch!(patch_hash: patch)
+            expect(@instance.first_name).to eql('Baz')
+          end
+
           it 'which updates nested values' do
             @instance.update!(first_name: 'Foo', last_name: 'Bar')
 


### PR DESCRIPTION
Hey @pond

Bit of a mouthful and I'm really just throwing spaghetti at the wall at this point to see if I'm barking up the right tree.

Microsoft's SCIM Validator strikes again. This time they're failing us on path-less replace operations not updating attributes when those attributes are in dotpath notation.

An example of a request is below:
```
PATCH https://app.colloquial.io/scim_v2/Users/326 1.1

Host: app.colloquial.io

Content-Type: application/scim+json; charset=utf-8

{
  "Operations": [
    {
      "op": "replace",
      "path": "emails[type eq \"work\"].value",
      "value": "trystan@bradtkekutch.us"
    },
    {
      "op": "replace",
      "value": {
        "userName": "lucienne_durgan@wiza.biz",
        "name.givenName": "Keith",
        "name.familyName": "Stella",
      }
    }
  ],
  "schemas": [
    "urn:ietf:params:scim:api:messages:2.0:PatchOp"
  ]
}
```

In this case their expectation is that the givenName is updated to Keith and the familyName is similarly updated. I've created a test case for this that's similar to an existing one. This test fails without the patch to create the `dot_pathed_value` hash, but is probably the wrong place for this to live.

Any thoughts or guidance on how I can get this over the line would be much appreciated!

Cheers
W