### PR TITLE
Generate schema location urls in controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ end
 
 All routes then will be available at `https://.../scim_v2/...` via controllers you write in `app/controllers/scim_v2/...`, e.g. `app/controllers/scim_v2/users_controller.rb`. More on controllers later.
 
+#### URL helpers
+
+Internally Scimitar always invokes URL helpers in the controller layer. I.e. any variable path parameters will be resolved by Rails automatically. If you need more control over the way URLs are generated you can override any URL helper by redefining it in the application controller mixin. See the [`application_controller_mixin` engine configuration option](https://github.com/RIPAGlobal/scimitar/blob/main/config/initializers/scimitar.rb).
+
 ### Data models
 
 Scimitar assumes that each SCIM resource maps to a single corresponding class in your system. This might be an abstraction over more complex underpinings, but either way, a 1:1 relationship is expected. For example, a SCIM User might map to a User ActiveRecord model in your Rails application, while a SCIM Group might map to some custom class called Team which operates on a more complex set of data "under the hood".

--- a/app/controllers/scimitar/schemas_controller.rb
+++ b/app/controllers/scimitar/schemas_controller.rb
@@ -4,6 +4,11 @@ module Scimitar
   class SchemasController < ApplicationController
     def index
       schemas = Scimitar::Engine.schemas
+
+      schemas.each do |schema|
+        schema.meta.location = scim_schemas_url(name: schema.id)
+      end
+
       schemas_by_id = schemas.reduce({}) do |hash, schema|
         hash[schema.id] = schema
         hash

--- a/app/models/scimitar/schema/base.rb
+++ b/app/models/scimitar/schema/base.rb
@@ -13,7 +13,7 @@ module Scimitar
 
       # Converts the schema to its json representation that will be returned by /SCHEMAS end-point of a SCIM service provider.
       def as_json(options = {})
-        @meta.location = Scimitar::Engine.routes.url_helpers.scim_schemas_path(name: id)
+        @meta.location ||= Scimitar::Engine.routes.url_helpers.scim_schemas_path(name: id)
         original = super
         original.merge('attributes' => original.delete('scim_attributes'))
       end

--- a/config/initializers/scimitar.rb
+++ b/config/initializers/scimitar.rb
@@ -37,10 +37,11 @@ Rails.application.config.to_prepare do # (required for >= Rails 7 / Zeitwerk)
   #
   Scimitar.engine_configuration = Scimitar::EngineConfiguration.new({
 
-    # If you have filters you want to run for any Scimitar action/route, you
-    # can define them here. For example, you might use a before-action to set
-    # up some multi-tenancy related state, or skip Rails CSRF token
-    # verification. For example:
+    # If you have filters you want to run for any Scimitar action/route, you can
+    # define them here. You can also override any shared controller methods
+    # here. For example, you might use a before-action to set up some
+    # multi-tenancy related state, skip Rails CSRF token verification, or
+    # customize how Scimitar generates URLs:
     #
     #     application_controller_mixin: Module.new do
     #       def self.included(base)
@@ -53,6 +54,10 @@ Rails.application.config.to_prepare do # (required for >= Rails 7 / Zeitwerk)
     #           skip_before_action    :verify_authenticity_token
     #           prepend_before_action :setup_some_kind_of_multi_tenancy_data
     #         end
+    #       end
+    #
+    #       def scim_schemas_url(options)
+    #         super(custom_param: 'value', **options)
     #       end
     #     end, # ...other configuration entries might follow...
 

--- a/spec/apps/dummy/config/initializers/scimitar.rb
+++ b/spec/apps/dummy/config/initializers/scimitar.rb
@@ -19,6 +19,14 @@ Rails.application.config.to_prepare do
           before_action :test_hook
         end
       end
+
+      def scim_schemas_url(options)
+        super(test: 1, **options)
+      end
+
+      def scim_resource_type_url(options)
+        super(test: 1, **options)
+      end
     end
 
   })

--- a/spec/controllers/scimitar/resource_types_controller_spec.rb
+++ b/spec/controllers/scimitar/resource_types_controller_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Scimitar::ResourceTypesController do
     it 'renders the resource type for user' do
       get :index, format: :scim
       response_hash = JSON.parse(response.body)
-      expected_response = [ Scimitar::Resources::User.resource_type(scim_resource_type_url(name: 'User')),
-                            Scimitar::Resources::Group.resource_type(scim_resource_type_url(name: 'Group'))
+      expected_response = [ Scimitar::Resources::User.resource_type(scim_resource_type_url(name: 'User', test: 1)),
+                            Scimitar::Resources::Group.resource_type(scim_resource_type_url(name: 'Group', test: 1))
       ].to_json
 
       response_hash = JSON.parse(response.body)

--- a/spec/controllers/scimitar/schemas_controller_spec.rb
+++ b/spec/controllers/scimitar/schemas_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Scimitar::SchemasController do
+  routes { Scimitar::Engine.routes }
 
   before(:each) { allow(controller).to receive(:authenticated?).and_return(true) }
 
@@ -24,6 +25,13 @@ RSpec.describe Scimitar::SchemasController do
       expect(response).to be_ok
       parsed_body = JSON.parse(response.body)
       expect(parsed_body['name']).to eql('User')
+    end
+
+    it 'includes the controller customized schema location' do
+      get :index, params: { name: Scimitar::Schema::User.id, format: :scim }
+      expect(response).to be_ok
+      parsed_body = JSON.parse(response.body)
+      expect(parsed_body.dig('meta', 'location')).to eq scim_schemas_url(name: Scimitar::Schema::User.id, test: 1)
     end
 
     it 'returns only the Group schema when its id is provided' do


### PR DESCRIPTION
Makes schema location URLs be generated in the controller. This way required keyword arguments for the URL helper are automatically revolved from the current path parameters. This solves an issues when Scimitar's routes are mounted inside a namespace with variable parameters. E.g. in our multitenant environment we have:

```rb
namespace :scim do
  namespace :v2 do
    resources :organizations, only: [] do
      mount Scimitar::Engine, at: '/'
      # etc...
    end
  end
end
```

In this case `#scim_schemas_url` requires the `:organization_id` key, which is omitted when the URL is generated in `Schema::Base#as_json`. This causes an error. Using the controller's URL helper fixes this.

Additionally, the controller's URL helpers can be overridden in a simple(r) manner, making Scimitar a bit more extensible. I have utilized this to test this change (see the application controller mixin for the tests).

The resource types controller already does a similar thing for resource type urls.