### PR TITLE
Add option to pass block to controller's #save!

### DIFF
--- a/app/controllers/scimitar/active_record_backed_resources_controller.rb
+++ b/app/controllers/scimitar/active_record_backed_resources_controller.rb
@@ -173,8 +173,11 @@ module Scimitar
         else
           record.save!
         end
-
       rescue ActiveRecord::RecordInvalid => exception
+        handle_invalid_record(exception.record)
+      end
+
+      def handle_invalid_record(record)
         joined_errors = record.errors.full_messages.join('; ')
 
         # https://tools.ietf.org/html/rfc7644#page-12

--- a/app/controllers/scimitar/active_record_backed_resources_controller.rb
+++ b/app/controllers/scimitar/active_record_backed_resources_controller.rb
@@ -153,7 +153,13 @@ module Scimitar
       # Save a record, dealing with validation exceptions by raising SCIM
       # errors.
       #
-      # +record+:: ActiveRecord subclass to save (via #save!).
+      # +record+:: ActiveRecord subclass to save.
+      #
+      # If you just let this superclass handle things, it'll call the standard
+      # +#save!+ method on the record. If you pass a block, then this block is
+      # invoked and passed the ActiveRecord model instance to be saved. You can
+      # then do things like calling a different method, using a service object of
+      # some kind, perform audit-related operations and so-on.
       #
       # The return value is not used internally, making life easier for
       # overriding subclasses to "do the right thing" / avoid mistakes (instead
@@ -161,8 +167,12 @@ module Scimitar
       # and relying upon this to generate correct response payloads - an early
       # version of the gem did this and it caused a confusing subclass bug).
       #
-      def save!(record)
-        record.save!
+      def save!(record, &block)
+        if block_given?
+          yield(record)
+        else
+          record.save!
+        end
 
       rescue ActiveRecord::RecordInvalid => exception
         joined_errors = record.errors.full_messages.join('; ')

--- a/app/controllers/scimitar/active_record_backed_resources_controller.rb
+++ b/app/controllers/scimitar/active_record_backed_resources_controller.rb
@@ -177,6 +177,10 @@ module Scimitar
         handle_invalid_record(exception.record)
       end
 
+      # Deal with validation errors by responding with an appropriate SCIM error.
+      #
+      # +record+:: The record with validation errors.
+      #
       def handle_invalid_record(record)
         joined_errors = record.errors.full_messages.join('; ')
 

--- a/spec/apps/dummy/app/controllers/custom_save_mock_users_controller.rb
+++ b/spec/apps/dummy/app/controllers/custom_save_mock_users_controller.rb
@@ -1,0 +1,24 @@
+# For tests only - uses custom 'save!' implementation which passes a block to
+# Scimitar::ActiveRecordBackedResourcesController#save!.
+#
+class CustomSaveMockUsersController < Scimitar::ActiveRecordBackedResourcesController
+
+  CUSTOM_SAVE_BLOCK_USERNAME_INDICATOR = 'Custom save-block invoked'
+
+  protected
+
+    def save!(_record)
+      super do | record |
+        record.update!(username: CUSTOM_SAVE_BLOCK_USERNAME_INDICATOR)
+      end
+    end
+
+    def storage_class
+      MockUser
+    end
+
+    def storage_scope
+      MockUser.all
+    end
+
+end

--- a/spec/apps/dummy/config/routes.rb
+++ b/spec/apps/dummy/config/routes.rb
@@ -21,6 +21,11 @@ Rails.application.routes.draw do
   #
   delete 'CustomDestroyUsers/:id', to: 'custom_destroy_mock_users#destroy'
 
+  # For testing blocks passed to ActiveRecordBackedResourcesController#save!
+  #
+  post 'CustomSaveUsers', to: 'custom_save_mock_users#create'
+  get 'CustomSaveUsers/:id', to: 'custom_save_mock_users#show'
+
   # For testing environment inside Scimitar::ApplicationController subclasses.
   #
   get  'CustomRequestVerifiers', to: 'custom_request_verifiers#index'

--- a/spec/requests/active_record_backed_resources_controller_spec.rb
+++ b/spec/requests/active_record_backed_resources_controller_spec.rb
@@ -397,6 +397,22 @@ RSpec.describe Scimitar::ActiveRecordBackedResourcesController do
       expect(result['scimType']).to eql('invalidValue')
       expect(result['detail']).to include('is reserved')
     end
+
+    it 'invokes a block if given one' do
+      mock_before = MockUser.all.to_a
+      attributes = { userName: '5' } # Minimum required by schema
+
+      expect_any_instance_of(CustomSaveMockUsersController).to receive(:create).once.and_call_original
+      expect {
+        post "/CustomSaveUsers", params: attributes.merge(format: :scim)
+      }.to change { MockUser.count }.by(1)
+
+      mock_after = MockUser.all.to_a
+      new_mock = (mock_after - mock_before).first
+
+      expect(response.status).to eql(201)
+      expect(new_mock.username).to eql(CustomSaveMockUsersController::CUSTOM_SAVE_BLOCK_USERNAME_INDICATOR)
+    end
   end # "context '#create' do"
 
   # ===========================================================================


### PR DESCRIPTION
Hi @pond, it's me [again](https://github.com/RIPAGlobal/scimitar/pull/71).

This time I extended `ActiveRecordBackedResourcesController#save!` to accept a block, so that subclasses may override the default `record.save!` call with their own saving logic, without having to reimplement the rescue clause for handling uniqueness errors. Also, it aligns nicely with the destroy action, which already accepts a block for a very similar reasons.

In our case we would like a service object to save the record and do some other stuff, because we do not want to employ AR callbacks for that other stuff. With these changes it can look like this:

```rb
def save!(record)
  super do
    Services::ManagedUser::Save.new(record).call
  end
end
```

This will be helpful in many situations. But sometimes it's not enough.

We are trying to make things work with an ActiveModel model that wraps an ActiveRecord record. It mostly delegates stuff to the wrapped record, but it has its own additional validations. That means that we'll need to rescue `ActiveModel::ValidationError` next to `ActiveRecord::InvalidRecord`. Therefore we need to override the rescue clause in #save!, but we'd still like to avoid copy-pasting all of the invalid record handling logic. Therefore I have extracted that logic to a separate method. This way we only need to copy-paste one method call, and we don't have to override the actual logic:

```rb
def save!(record)
  Services::ManagedUser::Save.new(record).call
rescue ActiveModel::ValidationError, ActiveRecord::InvalidRecord
  handle_invalid_record(record)
end
```

In short, both changes just add a bit more extensibility to the controller.

I would love to see this merged in one form or another. Thanks!