### PR TITLE
Multi-valued simple type validation

### DIFF
--- a/app/models/scimitar/schema/attribute.rb
+++ b/app/models/scimitar/schema/attribute.rb
@@ -93,12 +93,21 @@ module Scimitar
       end
 
       def valid_simple_type?(value)
-        valid = (type == 'string' && value.is_a?(String)) ||
+        if multiValued
+          valid = value.is_a?(Array) && value.all? { |v| simple_type?(v) }
+          errors.add(self.name, "or one of its elements has the wrong type. It has to be an array of #{self.type}s.") unless valid
+        else
+          valid = simple_type?(value)
+          errors.add(self.name, "has the wrong type. It has to be a(n) #{self.type}.") unless valid
+        end
+        valid
+      end
+
+      def simple_type?(value)
+        (type == 'string' && value.is_a?(String)) ||
           (type == 'boolean' && (value.is_a?(TrueClass) || value.is_a?(FalseClass))) ||
           (type == 'integer' && (value.is_a?(Integer))) ||
           (type == 'dateTime' && valid_date_time?(value))
-        errors.add(self.name, "has the wrong type. It has to be a(n) #{self.type}.") unless valid
-        valid
       end
 
       def valid_date_time?(value)

--- a/spec/models/scimitar/schema/attribute_spec.rb
+++ b/spec/models/scimitar/schema/attribute_spec.rb
@@ -46,6 +46,28 @@ RSpec.describe Scimitar::Schema::Attribute do
       expect(attribute.errors.messages.to_h).to eql({userName: ['has the wrong type. It has to be a(n) string.']})
     end
 
+    it 'is valid if multi-valued and type is string and given value is an array of strings' do
+      attribute = described_class.new(name: 'scopes', multiValued: true, type: 'string')
+      expect(attribute.valid?(['something', 'something else'])).to be(true)
+    end
+
+    it 'is valid if multi-valued and type is string and given value is an empty array' do
+      attribute = described_class.new(name: 'scopes', multiValued: true, type: 'string')
+      expect(attribute.valid?([])).to be(true)
+    end
+
+    it 'is invalid if multi-valued and type is string and given value is not an array' do
+      attribute = described_class.new(name: 'scopes', multiValued: true, type: 'string')
+      expect(attribute.valid?('something')).to be(false)
+      expect(attribute.errors.messages.to_h).to eql({scopes: ['or one of its elements has the wrong type. It has to be an array of strings.']})
+    end
+
+    it 'is invalid if multi-valued and type is string and given value is an array containing another type' do
+      attribute = described_class.new(name: 'scopes', multiValued: true, type: 'string')
+      expect(attribute.valid?(['something', 123])).to be(false)
+      expect(attribute.errors.messages.to_h).to eql({scopes: ['or one of its elements has the wrong type. It has to be an array of strings.']})
+    end
+
     it 'is valid if type is boolean and given value is boolean' do
       expect(described_class.new(name: 'name', type: 'boolean').valid?(false)).to be(true)
       expect(described_class.new(name: 'name', type: 'boolean').valid?(true)).to be(true)


### PR DESCRIPTION
Hi @pond,

This one fixes an issue where a multi-valued string attribute did not accept an array of strings because validation of simple types didn't account for the `multiValued` property. We use such an attribute in a custom schema extension, and it should be possible within the specification. (There are even some standard attributes that are arrays of simple types, for instance `referenceTypes`.)

Thanks again,
Sjoerd