### PR TITLE
Remove default type from 'address'

### DIFF
--- a/app/models/scimitar/complex_types/address.rb
+++ b/app/models/scimitar/complex_types/address.rb
@@ -7,12 +7,6 @@ module Scimitar
     #
     class Address < Base
       set_schema Scimitar::Schema::Address
-
-      # Returns the JSON representation of an Address.
-      #
-      def as_json(options = {})
-        {'type' => 'work'}.merge(super(options))
-      end
     end
   end
 end

--- a/spec/models/scimitar/complex_types/address_spec.rb
+++ b/spec/models/scimitar/complex_types/address_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 RSpec.describe Scimitar::ComplexTypes::Address do
   context '#as_json' do
-    it 'assumes a type of "work" as a default' do
-      expect(described_class.new.as_json).to eq('type' => 'work')
+    it 'assumes no defaults' do
+      expect(described_class.new.as_json).to eq({})
     end
 
     it 'allows a custom address type' do
@@ -11,9 +11,8 @@ RSpec.describe Scimitar::ComplexTypes::Address do
     end
 
     it 'shows the set address' do
-      expect(described_class.new(country: 'NZ').as_json).to eq('type' => 'work', 'country' => 'NZ')
+      expect(described_class.new(country: 'NZ').as_json).to eq('country' => 'NZ')
     end
   end
 
 end
-


### PR DESCRIPTION
In issue #87, it's pointed out that the Address complex type has a default `type` of `work`, which is unusual; such defaults were removed from other types in https://github.com/RIPAGlobal/scimitar/commit/19bab37ac846d35eee943ab20fb563cdaa107a8a.

This PR removes the default, though we must exercise caution when releasing a version of Scimitar with the change included as it _might_ be a breaking change for some clients.

(The release strategy is _probably_ still to call it 2.7.0 as it's not clear if this would break anyone, but warn in the change log - _hopefully_ that's sufficient.).