### PR TITLE
Account for nil for non-required complex type attributes

### DIFF
--- a/app/models/scimitar/resources/base.rb
+++ b/app/models/scimitar/resources/base.rb
@@ -129,7 +129,7 @@ module Scimitar
 
           if scim_attribute && scim_attribute.complexType
             if scim_attribute.multiValued
-              self.send("#{attr_name}=", attr_value.map {|attr_for_each_item| complex_type_from_hash(scim_attribute, attr_for_each_item)})
+              self.send("#{attr_name}=", attr_value&.map {|attr_for_each_item| complex_type_from_hash(scim_attribute, attr_for_each_item)})
             else
               self.send("#{attr_name}=", complex_type_from_hash(scim_attribute, attr_value))
             end

--- a/spec/models/scimitar/resources/base_spec.rb
+++ b/spec/models/scimitar/resources/base_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe Scimitar::Resources::Base do
     end
 
     context '#initialize' do
+      it 'accepts nil for non-required attributes' do
+        resource = CustomResourse.new(name: nil, names: nil, privateName: nil)
+
+        expect(resource.name).to be_nil
+        expect(resource.names).to be_nil
+        expect(resource.privateName).to be_nil
+      end
+
       shared_examples 'an initializer' do | force_upper_case: |
         it 'which builds the nested type' do
           attributes = {


### PR DESCRIPTION
👋 @pond,

Initialising a resources with `nil` for a non-required multi valued complex type attribute resulted in a NoMethodError (nil#map). This PR fixes that.