### PR TITLE
Remove verify_authenticity_token from  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,6 @@ If you use ActiveRecord, your controllers can potentially be extremely simple by
 module Scim
   class UsersController < Scimitar::ActiveRecordBackedResourcesController
 
-    skip_before_action :verify_authenticity_token
-
     protected
 
       def storage_class


### PR DESCRIPTION
`remove skip_before_action :verify_authenticity_token`

It not need actually, it's an error if this line is present