### PR TITLE
Configure load paths of controllers and models

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,15 +79,6 @@ Scimitar.engine_configuration = Scimitar::EngineConfiguration.new({
 
 When it comes to token access, Scimitar neither enforces nor presumes any kind of encoding for bearer tokens. You can use anything you like, including encoding/encrypting JWTs if you so wish - https://rubygems.org/gems/jwt may be useful. The way in which a client might integrate with your SCIM service varies by client and you will have to check documentation to see how a token gets conveyed to that client in the first place (e.g. a full OAuth flow with your application, or just a static token generated in some UI which an administrator copies and pastes into their client's SCIM configuration UI).
 
-**Important:** Under Rails 7 or later, you may need to wrap any Scimitar configuration with `Rails.application.config.to_prepare do...` to avoid `NameError: uninitialized constant...` exceptions arising due to autoloader problems:
-
-```ruby
-Rails.application.config.to_prepare do
-  Scimitar.engine_configuration = Scimitar::EngineConfiguration.new({
-    # ...
-  end
-end
-```
 
 ### Routes
 

--- a/app/controllers/scimitar/active_record_backed_resources_controller.rb
+++ b/app/controllers/scimitar/active_record_backed_resources_controller.rb
@@ -1,5 +1,3 @@
-require_dependency "scimitar/application_controller"
-
 module Scimitar
 
   # An ActiveRecord-centric subclass of Scimitar::ResourcesController. See that

--- a/app/controllers/scimitar/active_record_backed_resources_controller.rb
+++ b/app/controllers/scimitar/active_record_backed_resources_controller.rb
@@ -17,7 +17,7 @@ module Scimitar
   #
   class ActiveRecordBackedResourcesController < ResourcesController
 
-    rescue_from ActiveRecord::RecordNotFound, with: :handle_resource_not_found # See Scimitar::ApplicationController
+    rescue_from 'ActiveRecord::RecordNotFound', with: :handle_resource_not_found # See Scimitar::ApplicationController
 
     before_action :obtain_id_column_name_from_attribute_map
 

--- a/app/controllers/scimitar/resource_types_controller.rb
+++ b/app/controllers/scimitar/resource_types_controller.rb
@@ -1,5 +1,3 @@
-require_dependency "scimitar/application_controller"
-
 module Scimitar
   class ResourceTypesController < ApplicationController
     def index

--- a/app/controllers/scimitar/resources_controller.rb
+++ b/app/controllers/scimitar/resources_controller.rb
@@ -1,5 +1,3 @@
-require_dependency "scimitar/application_controller"
-
 module Scimitar
 
   # A Rails controller which is mostly idiomatic, with #index, #show, #create

--- a/app/controllers/scimitar/schemas_controller.rb
+++ b/app/controllers/scimitar/schemas_controller.rb
@@ -1,5 +1,3 @@
-require_dependency "scimitar/application_controller"
-
 module Scimitar
   class SchemasController < ApplicationController
     def index

--- a/app/controllers/scimitar/service_provider_configurations_controller.rb
+++ b/app/controllers/scimitar/service_provider_configurations_controller.rb
@@ -1,4 +1,3 @@
-require_dependency "scimitar/application_controller"
 module Scimitar
   class ServiceProviderConfigurationsController < ApplicationController
     def show

--- a/lib/scimitar/engine.rb
+++ b/lib/scimitar/engine.rb
@@ -1,6 +1,12 @@
+require 'rails/engine'
+
 module Scimitar
-  class Engine < ::Rails::Engine
+  class Engine < Rails::Engine
     isolate_namespace Scimitar
+    config.autoload_once_paths = %W(
+      #{root}/app/controllers
+      #{root}/app/models
+    )
 
     Mime::Type.register 'application/scim+json', :scim
 


### PR DESCRIPTION
Hey thanks for the work on this gem. I saw the note on wrapping the initializer in `Rails.application.config.to_prepare` and thought I would fix that. I'm not sure how open you guys are to PRs.

* Autoload once the app/controllers and app/models directories to prevent the uninitialized constants error.
* Removed `require_dependency` since it's obsolete and not needed with autoloading. 
* Removed the note in the readme about Rails 7 NameError.
