### PR TITLE
Fix non-returnables

### DIFF
--- a/app/models/scimitar/resources/base.rb
+++ b/app/models/scimitar/resources/base.rb
@@ -137,18 +137,21 @@ module Scimitar
         end
       end
 
+      # Renders *in full* as JSON; typically used for write-based operations...
+      #
+      #     record = self.storage_class().new
+      #     record.from_scim!(scim_hash: scim_resource.as_json())
+      #     self.save!(record)
+      #
+      # ...so all fields, even those marked "returned: false", are included.
+      # Use Scimitar::Resources::Mixin::to_scim to obtain a SCIM object with
+      # returnable fields omitted, rendering *that* as JSON via #to_json.
+      #
       def as_json(options = {})
         self.meta = Meta.new unless self.meta && self.meta.is_a?(Meta)
         self.meta.resourceType = self.class.resource_type_id
 
-        non_returnable_attributes = self.class
-          .schemas
-          .flat_map(&:scim_attributes)
-          .filter_map { |attribute| attribute.name if attribute.returned == 'never' }
-
-        non_returnable_attributes << 'errors'
-
-        original_hash = super(options).except(*non_returnable_attributes)
+        original_hash = super(options).except('errors')
         original_hash.merge!('schemas' => self.class.schemas.map(&:id))
 
         self.class.extended_schemas.each do |extension_schema|

--- a/app/models/scimitar/schema/name.rb
+++ b/app/models/scimitar/schema/name.rb
@@ -6,7 +6,7 @@ module Scimitar
 
       def self.scim_attributes
         @scim_attributes ||= [
-          Attribute.new(name: 'familyName',       type: 'string', required: true, returned: false),
+          Attribute.new(name: 'familyName',       type: 'string', required: true),
           Attribute.new(name: 'givenName',        type: 'string', required: true),
           Attribute.new(name: 'middleName',       type: 'string'),
           Attribute.new(name: 'formatted',        type: 'string'),

--- a/app/models/scimitar/schema/name.rb
+++ b/app/models/scimitar/schema/name.rb
@@ -6,7 +6,7 @@ module Scimitar
 
       def self.scim_attributes
         @scim_attributes ||= [
-          Attribute.new(name: 'familyName',       type: 'string', required: true),
+          Attribute.new(name: 'familyName',       type: 'string', required: true, returned: false),
           Attribute.new(name: 'givenName',        type: 'string', required: true),
           Attribute.new(name: 'middleName',       type: 'string'),
           Attribute.new(name: 'formatted',        type: 'string'),

--- a/spec/models/scimitar/resources/base_spec.rb
+++ b/spec/models/scimitar/resources/base_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Scimitar::Resources::Base do
             name: 'names', multiValued: true, complexType: Scimitar::ComplexTypes::Name, required: false
           ),
           Scimitar::Schema::Attribute.new(
-            name: 'privateName', complexType: Scimitar::ComplexTypes::Name, required: false, returned: false
+            name: 'privateName', complexType: Scimitar::ComplexTypes::Name, required: false, returned: 'never'
           ),
         ]
       end

--- a/spec/requests/active_record_backed_resources_controller_spec.rb
+++ b/spec/requests/active_record_backed_resources_controller_spec.rb
@@ -345,6 +345,7 @@ RSpec.describe Scimitar::ActiveRecordBackedResourcesController do
 
           attributes = {
             userName: '4',
+            password: 'correcthorsebatterystaple',
             name: {
               givenName: 'Given',
               familyName: 'Family'
@@ -379,6 +380,7 @@ RSpec.describe Scimitar::ActiveRecordBackedResourcesController do
           expect(result['id']).to eql(new_mock.id.to_s)
           expect(result['meta']['resourceType']).to eql('User')
           expect(new_mock.username).to eql('4')
+          expect(new_mock.password).to eql('correcthorsebatterystaple')
           expect(new_mock.first_name).to eql('Given')
           expect(new_mock.last_name).to eql('Family')
           expect(new_mock.home_email_address).to eql('home_4@test.com')


### PR DESCRIPTION
# DRAFT

A variation of #103 after the report of the quite serious bug that on-create/update attributes like `password` were being ignored. See #103 for conversation history - TL;DR, looks like `as_json` was the wrong place and `to_scim` is the right one for the masking out of non-returnable attributes.

