### PR TITLE
fix: allow attribute names starting with operator chars to be filtered

### DIFF
--- a/app/models/scimitar/lists/query_parser.rb
+++ b/app/models/scimitar/lists/query_parser.rb
@@ -65,7 +65,7 @@ module Scimitar
 
       PAREN       = /[\(\)]/.freeze
       STR         = /"(?:\\"|[^"])*"/.freeze
-      OP          = /#{OPERATORS.keys.join('|')}/i.freeze
+      OP          = /(?:#{OPERATORS.keys.join('|')})\b/i.freeze
       WORD        = /[\w\.]+/.freeze
       SEP         = /\s?/.freeze
       NEXT_TOKEN  = /\A(#{PAREN}|#{STR}|#{OP}|#{WORD})#{SEP}/.freeze

--- a/spec/apps/dummy/app/models/mock_user.rb
+++ b/spec/apps/dummy/app/models/mock_user.rb
@@ -96,6 +96,7 @@ class MockUser < ActiveRecord::Base
       #
       organization: :organization,
       department:   :department,
+      primaryEmail: :scim_primary_email,
       userGroups: [
         {
           list:      :mock_groups,
@@ -124,8 +125,14 @@ class MockUser < ActiveRecord::Base
       'groups.value'      => { column: MockGroup.arel_table[:id] },
       'emails'            => { columns: [ :work_email_address, :home_email_address ] },
       'emails.value'      => { columns: [ :work_email_address, :home_email_address ] },
-      'emails.type'       => { ignore: true } # We can't filter on that; it'll just search all e-mails
+      'emails.type'       => { ignore: true }, # We can't filter on that; it'll just search all e-mails
+      'primaryEmail'      => { column: :scim_primary_email },
     }
+  end
+
+  # reader
+  def scim_primary_email
+    work_email_address
   end
 
   include Scimitar::Resources::Mixin

--- a/spec/apps/dummy/config/initializers/scimitar.rb
+++ b/spec/apps/dummy/config/initializers/scimitar.rb
@@ -50,7 +50,8 @@ Rails.application.config.to_prepare do
         def self.scim_attributes
           [
             Scimitar::Schema::Attribute.new(name: 'organization', type: 'string'),
-            Scimitar::Schema::Attribute.new(name: 'department',   type: 'string')
+            Scimitar::Schema::Attribute.new(name: 'department',   type: 'string'),
+            Scimitar::Schema::Attribute.new(name: 'primaryEmail', type: 'string'),
           ]
         end
       end

--- a/spec/models/scimitar/lists/query_parser_spec.rb
+++ b/spec/models/scimitar/lists/query_parser_spec.rb
@@ -60,6 +60,15 @@ RSpec.describe Scimitar::Lists::QueryParser do
       expect(%Q("O'Malley")).to eql(tree[2])
     end
 
+    it "extended attribute equals" do
+      @instance.parse(%Q(primaryEmail eq "foo@bar.com"))
+
+      rpn = @instance.rpn
+      expect('primaryEmail').to eql(rpn[0])
+      expect(%Q("foo@bar.com")).to eql(rpn[1])
+      expect('eq').to eql(rpn[2])
+    end
+
     it "user name starts with" do
       @instance.parse(%Q(userName sw "J"))
 

--- a/spec/models/scimitar/resources/mixin_spec.rb
+++ b/spec/models/scimitar/resources/mixin_spec.rb
@@ -296,7 +296,8 @@ RSpec.describe Scimitar::Resources::Mixin do
 
             'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User' => {
               'organization' => 'SOMEORG',
-              'department'   => nil
+              'department'   => nil,
+              'primaryEmail' => instance.work_email_address
             }
           })
         end


### PR DESCRIPTION
Fixes #114