### PR TITLE
Schema-attribute-to-mapped-attribute matching for 'Schemas' endpoint

### DIFF
--- a/app/controllers/scimitar/schemas_controller.rb
+++ b/app/controllers/scimitar/schemas_controller.rb
@@ -18,63 +18,22 @@ module Scimitar
         schemas
       end
 
-      # Figure out which classes (of those currently loaded - autoloaders take
-      # note!) use the Scimitar resource mixin. The resource classes tell us
-      # which SCIM resource class they represent and that, in turn, tells us
-      # which schema(s) are involved; the resource classes also contain the
-      # SCIM schema to local class attribute map.
+      # Now we either have a simple render method, or a complex one.
       #
-      classes_using_scimitar_mixin = Module.constants.filter_map do |c|
-        value = Module.const_get(c) rescue nil
-
-        value if (
-          value.is_a?(Class) &&
-          value.include?(Scimitar::Resources::Mixin) &&
-          value.respond_to?(:scim_resource_type) &&
-          value.respond_to?(:scim_attributes_map)
-        )
+      schema_to_render = if Scimitar.engine_configuration.schema_list_from_attribute_mappings.empty?
+        list
+      else
+        self.redraw_schema_list_using_mappings(list)
       end
-
-      # Take the schema list and map it to rewritten versions based on finding
-      # out which of the above resource classes use a given schema and then
-      # walking this schema's attribute tree while comparing notes against the
-      # resource class's attribute map. Unmapped attributes are removed and the
-      # reality of resource class attribute mutability might cause a different
-      # answer for the corresponding schema attribute's mutability; for any
-      # custom schema we'd expect a match, but for core schema where the local
-      # resources don't quite work to spec, at least the /Schemas endpoint can
-      # try to reflect reality and aid auto-discovery.
-      #
-      list.map! do | schema_instance |
-        found_class = classes_using_scimitar_mixin.find do | class_using_scimitar_mixin |
-          resource_class = class_using_scimitar_mixin.scim_resource_type()
-
-          resource_class.schema == schema_instance.class ||
-          resource_class.extended_schemas.include?(schema_instance.class)
-        end
-
-        rebuilt_schema_instance = if found_class
-          rebuild_schema_through_mappings(
-            original_schema_instance:   schema_instance,
-            class_using_scimitar_mixin: found_class
-          )
-        else
-          nil
-        end
-
-        rebuilt_schema_instance
-      end
-
-      list.compact!
 
       render(json: {
         schemas: [
             'urn:ietf:params:scim:api:messages:2.0:ListResponse'
         ],
-        totalResults: list.size,
+        totalResults: schema_to_render.size,
         startIndex:   1,
-        itemsPerPage: list.size,
-        Resources:    list
+        itemsPerPage: schema_to_render.size,
+        Resources:    schema_to_render
       })
     end
 
@@ -84,28 +43,149 @@ module Scimitar
     #
     private
 
+      # Given a list of schema *instances*, find all Scimitar::Resources::Mixin
+      # inclusions to obtain classes with a ::scim_resource_type implementation
+      # that is invoked to get at the associated Scimitar resource class; each
+      # resource class then describes the schema it uses; the list is filtered
+      # to include only those found schemas. Then, for each, use the discovered
+      # class' attribute maps to walk the schema attribute tree alongside the
+      # map and render only mapped attributes. This is done via calling down to
+      # ::redraw_schema_using_mappings for each remaining schema in the list.
+      #
+      # An array of new schema data is returned.
+      #
+      # +list+:: Array of schema instances to examine.
+      #
+      def redraw_schema_list_using_mappings(list)
 
-      # NB note in docs that it's not necessarily *all* dup'd so don't assume
-      # it (case of associated lists where class inside list cannot be determined)
+        # Iterate over the configured model classes to build a mapping from
+        # Scimitar schema class to an array of one or more model classes that
+        # seem to use it. This is to detect the error condition wherein some
+        # schema gets used more than once, leading to multiple possible
+        # attribute map choices.
+        #
+        classes_using_scimitar_mixin = Scimitar.engine_configuration.schema_list_from_attribute_mappings
+        schema_to_resource_map       = {}
 
+        classes_using_scimitar_mixin.each do | model_class |
+          resource_class = model_class.scim_resource_type()
+          schemas        = resource_class.extended_schemas + [resource_class.schema]
 
-      def rebuild_schema_through_mappings(
+          schemas.each do | schema_class |
+            schema_to_resource_map[schema_class] ||= []
+            schema_to_resource_map[schema_class] <<  model_class
+          end
+        end
+
+        # Take the schema list and map to rewritten versions based on finding
+        # out which of the above resource classes use a given schema and then
+        # walking this schema's attribute tree while comparing against the
+        # resource class's attribute map. Unmapped attributes are removed. The
+        # reality of resource class attribute mutability might give different
+        # answers for the corresponding schema attribute's mutability; for any
+        # custom schema we'd expect a match, but for core schema where local
+        # resources don't quite work to spec, at least the /Schemas endpoint
+        # can try to reflect reality and aid auto-discovery.
+        #
+        redrawn_list = list.map do | schema_instance |
+          resource_classes_using_schema = schema_to_resource_map[schema_instance.class]
+
+          if resource_classes_using_schema.nil?
+            next # NOTE EARLY LOOP RESTART (schema not used by a resource)
+          elsif resource_classes_using_schema.size > 1
+            raise "Cannot infer attribute map for engine configuration 'schema_list_from_attribute_mappings: true' because multiple resource classes use schema '#{schema_instance.class.name}': #{resource_classes_using_schema.map(&:name).join(', ')}"
+          end
+
+          found_class = classes_using_scimitar_mixin.find do | class_using_scimitar_mixin |
+            resource_class = class_using_scimitar_mixin.scim_resource_type()
+
+            resource_class.schema == schema_instance.class ||
+            resource_class.extended_schemas.include?(schema_instance.class)
+          end
+
+          rebuilt_schema_instance = if found_class
+            redraw_schema_using_mappings(
+              original_schema_instance: schema_instance,
+              instance_including_mixin: found_class.new
+            )
+          else
+            nil
+          end
+
+          rebuilt_schema_instance
+        end
+
+        redrawn_list.compact!
+        redrawn_list
+      end
+
+      # "Redraw" a schema, by walking its attribute tree alongside a related
+      # resource class's attribute map. Only mapped attributes are included.
+      # The mapped model is checked for a read accessor and write ability is
+      # determined via Scimitar::Resources::Mixin#scim_mutable_attributes. This
+      # gives the actual read/write ability of the mapped attribute; if the
+      # schema's declared mutability differs, the *most restrictive* is chosen.
+      # For example, if the schema says read-write but the mapped model only
+      # has read ability, then "readOnly" is used. Conversely, if the schema
+      # says read-only but the mapped model has read-write, the schema's
+      # "readOnly" is chosen instead as the source of truth.
+      #
+      # See the implementation's comments for a table describing exactly how
+      # all mutability conflict cases are resolved.
+      #
+      # The returned schema instance may be a full or partial duplicate of the
+      # one given on input - some or all attributes and/or sub-attributes may
+      # have been duplicated due to e.g. mutability differences. Do not assume
+      # or rely upon this as a caller.
+      #
+      # Mandatory named parameters for external callers are:
+      #
+      # +original_schema_instance+::   The Scimitar::Schema::Base subclass
+      #                                schema *instance* that is to be examined
+      #                                and possibly "redrawn".
+      #
+      # +instance_including_mixin+::   Instance of the model class including
+      #                                Scimitar::Resources::Mixin, providing
+      #                                the attribute map to be examined.
+      #
+      # Named parameters used internally for recursive calls are:
+      #
+      # +scim_attributes_map+::        The fragment of the attribute map found
+      #                                from +instance_including_mixin+'s class
+      #                                initially, which is relevant to the
+      #                                current recursion level. E.g. it might
+      #                                be the sub-attributes map of "name",
+      #                                for things like a "familyName" mapping.
+      #
+      # +schema_attributes+::          An array of schema attributes for the
+      #                                current recursion level, corresponding
+      #                                to +scim_attributes_map+.
+      #
+      # +rebuilt_attribute_array+::    Redrawn schema attributes are collected
+      #                                into this array, which is altered in
+      #                                place. It is usually a 'subAttributes'
+      #                                property of a schema attribute that's
+      #                                provoked recursion in order to examine
+      #                                and rebuild its sub-attributes directly.
+      #
+      def redraw_schema_using_mappings(
         original_schema_instance:,
-        class_using_scimitar_mixin:,
+        instance_including_mixin:,
 
         scim_attributes_map:     nil,
         schema_attributes:       nil,
         rebuilt_attribute_array: nil
       )
         schema_attributes   ||= original_schema_instance.scim_attributes
-        scim_attributes_map ||= class_using_scimitar_mixin
+        scim_attributes_map ||= instance_including_mixin
+          .class
           .scim_attributes_map()
           .with_indifferent_case_insensitive_access()
 
         rebuilt_schema_instance = nil
 
         if rebuilt_attribute_array.nil?
-          rebuilt_schema_instance                 = original_schema_instance.dup()
+          rebuilt_schema_instance                 = self.duplicate_attribute(original_schema_instance)
           rebuilt_schema_instance.scim_attributes = []
           rebuilt_attribute_array                 = rebuilt_schema_instance.scim_attributes
         end
@@ -135,9 +215,10 @@ module Scimitar
 
                 if (
                   associated_resource_class.nil? &&
-                  class_using_scimitar_mixin < ActiveRecord::Base
+                  instance_including_mixin.is_a?(ActiveRecord::Base)
                 )
-                  associated_resource_class = class_using_scimitar_mixin
+                  associated_resource_class = instance_including_mixin
+                    .class
                     .reflect_on_association(mapped_multivalue_attribute.first[:list])
                     &.klass
                 end
@@ -145,16 +226,16 @@ module Scimitar
                 if associated_resource_class.nil? || ! associated_resource_class.include?(Scimitar::Resources::Mixin)
                   rebuilt_attribute_array << schema_attribute
                 else
-                  rebuilt_schema_attribute = schema_attribute.dup()
+                  rebuilt_schema_attribute = self.duplicate_attribute(schema_attribute)
                   rebuilt_schema_attribute.subAttributes = []
                   rebuilt_attribute_array << rebuilt_schema_attribute
 
-                  rebuild_schema_through_mappings(
-                    original_schema_instance:   original_schema_instance,
-                    class_using_scimitar_mixin: associated_resource_class,
-                    scim_attributes_map:        mapped_multivalue_attribute.first[:using],
-                    schema_attributes:          schema_attribute.subAttributes,
-                    rebuilt_attribute_array:    rebuilt_schema_attribute.subAttributes
+                  redraw_schema_using_mappings(
+                    original_schema_instance: original_schema_instance,
+                    instance_including_mixin: associated_resource_class.new,
+                    scim_attributes_map:      mapped_multivalue_attribute.first[:using],
+                    schema_attributes:        schema_attribute.subAttributes,
+                    rebuilt_attribute_array:  rebuilt_schema_attribute.subAttributes
                   )
                 end
 
@@ -176,16 +257,16 @@ module Scimitar
                   union_of_mappings.merge!(mapped_multivalue_attribute_description[:using])
                 end
 
-                rebuilt_schema_attribute = schema_attribute.dup()
+                rebuilt_schema_attribute = self.duplicate_attribute(schema_attribute)
                 rebuilt_schema_attribute.subAttributes = []
                 rebuilt_attribute_array << rebuilt_schema_attribute
 
-                rebuild_schema_through_mappings(
-                  original_schema_instance:   original_schema_instance,
-                  class_using_scimitar_mixin: class_using_scimitar_mixin,
-                  scim_attributes_map:        union_of_mappings,
-                  schema_attributes:          schema_attribute.subAttributes,
-                  rebuilt_attribute_array:    rebuilt_schema_attribute.subAttributes
+                redraw_schema_using_mappings(
+                  original_schema_instance: original_schema_instance,
+                  instance_including_mixin: instance_including_mixin,
+                  scim_attributes_map:      union_of_mappings,
+                  schema_attributes:        schema_attribute.subAttributes,
+                  rebuilt_attribute_array:  rebuilt_schema_attribute.subAttributes
                 )
               end
             end
@@ -194,16 +275,16 @@ module Scimitar
             mapped_subattributes = scim_attributes_map[schema_attribute.name]
 
             if mapped_subattributes.is_a?(Hash)
-              rebuilt_schema_attribute = schema_attribute.dup()
+              rebuilt_schema_attribute = self.duplicate_attribute(schema_attribute)
               rebuilt_schema_attribute.subAttributes = []
               rebuilt_attribute_array << rebuilt_schema_attribute
 
-              rebuild_schema_through_mappings(
-                original_schema_instance:   original_schema_instance,
-                class_using_scimitar_mixin: class_using_scimitar_mixin,
-                scim_attributes_map:        mapped_subattributes,
-                schema_attributes:          schema_attribute.subAttributes,
-                rebuilt_attribute_array:    rebuilt_schema_attribute.subAttributes
+              redraw_schema_using_mappings(
+                original_schema_instance: original_schema_instance,
+                instance_including_mixin: instance_including_mixin,
+                scim_attributes_map:      mapped_subattributes,
+                schema_attributes:        schema_attribute.subAttributes,
+                rebuilt_attribute_array:  rebuilt_schema_attribute.subAttributes
               )
             end
 
@@ -211,13 +292,13 @@ module Scimitar
             mapped_attribute = scim_attributes_map[schema_attribute.name]
 
             unless mapped_attribute.nil?
-              rebuilt_schema_attribute = schema_attribute.dup()
+              rebuilt_schema_attribute = self.duplicate_attribute(schema_attribute)
               has_mapped_reader        = true
               has_mapped_writer        = false
 
               if mapped_attribute.is_a?(String) || mapped_attribute.is_a?(Symbol)
-                has_mapped_reader = class_using_scimitar_mixin.new.respond_to?(mapped_attribute)
-                has_mapped_writer = class_using_scimitar_mixin.new.respond_to?("#{mapped_attribute}=")
+                has_mapped_reader = instance_including_mixin.respond_to?(mapped_attribute)
+                has_mapped_writer = instance_including_mixin.scim_mutable_attributes().include?(mapped_attribute.to_sym)
               end
 
               # The schema is taken as the primary source of truth, leading to
@@ -278,6 +359,20 @@ module Scimitar
         end
 
         return rebuilt_schema_instance # (meaningless except for topmost call)
+      end
+
+      # Small helper that duplicates Scimitar::Schema::Attribute instances, but
+      # then removes their 'errors' collection which otherwise gets initialised
+      # to an empty value and is rendered as if part of the schema (which isn't
+      # a valid entry in a SCIM schema representation).
+      #
+      # +schema_attribute+:: Scimitar::Schema::Attribute to be duplicated.
+      #                      A renderable duplicate is returned.
+      #
+      def duplicate_attribute(schema_attribute)
+        duplicated_schema_attribute = schema_attribute.dup()
+        duplicated_schema_attribute.remove_instance_variable('@errors')
+        duplicated_schema_attribute
       end
 
   end

--- a/app/controllers/scimitar/schemas_controller.rb
+++ b/app/controllers/scimitar/schemas_controller.rb
@@ -18,6 +18,55 @@ module Scimitar
         schemas
       end
 
+      # Figure out which classes (of those currently loaded - autoloaders take
+      # note!) use the Scimitar resource mixin. The resource classes tell us
+      # which SCIM resource class they represent and that, in turn, tells us
+      # which schema(s) are involved; the resource classes also contain the
+      # SCIM schema to local class attribute map.
+      #
+      classes_using_scimitar_mixin = Module.constants.filter_map do |c|
+        value = Module.const_get(c) rescue nil
+
+        value if (
+          value.is_a?(Class) &&
+          value.include?(Scimitar::Resources::Mixin) &&
+          value.respond_to?(:scim_resource_type) &&
+          value.respond_to?(:scim_attributes_map)
+        )
+      end
+
+      # Take the schema list and map it to rewritten versions based on finding
+      # out which of the above resource classes use a given schema and then
+      # walking this schema's attribute tree while comparing notes against the
+      # resource class's attribute map. Unmapped attributes are removed and the
+      # reality of resource class attribute mutability might cause a different
+      # answer for the corresponding schema attribute's mutability; for any
+      # custom schema we'd expect a match, but for core schema where the local
+      # resources don't quite work to spec, at least the /Schemas endpoint can
+      # try to reflect reality and aid auto-discovery.
+      #
+      list.map! do | schema_instance |
+        found_class = classes_using_scimitar_mixin.find do | class_using_scimitar_mixin |
+          resource_class = class_using_scimitar_mixin.scim_resource_type()
+
+          resource_class.schema == schema_instance.class ||
+          resource_class.extended_schemas.include?(schema_instance.class)
+        end
+
+        rebuilt_schema_instance = if found_class
+          rebuild_schema_through_mappings(
+            original_schema_instance:   schema_instance,
+            class_using_scimitar_mixin: found_class
+          )
+        else
+          nil
+        end
+
+        rebuilt_schema_instance
+      end
+
+      list.compact!
+
       render(json: {
         schemas: [
             'urn:ietf:params:scim:api:messages:2.0:ListResponse'
@@ -28,6 +77,208 @@ module Scimitar
         Resources:    list
       })
     end
+
+    # =========================================================================
+    # PRIVATE INSTANCE METHODS
+    # =========================================================================
+    #
+    private
+
+
+      # NB note in docs that it's not necessarily *all* dup'd so don't assume
+      # it (case of associated lists where class inside list cannot be determined)
+
+
+      def rebuild_schema_through_mappings(
+        original_schema_instance:,
+        class_using_scimitar_mixin:,
+
+        scim_attributes_map:     nil,
+        schema_attributes:       nil,
+        rebuilt_attribute_array: nil
+      )
+        schema_attributes   ||= original_schema_instance.scim_attributes
+        scim_attributes_map ||= class_using_scimitar_mixin
+          .scim_attributes_map()
+          .with_indifferent_case_insensitive_access()
+
+        rebuilt_schema_instance = nil
+
+        if rebuilt_attribute_array.nil?
+          rebuilt_schema_instance                 = original_schema_instance.dup()
+          rebuilt_schema_instance.scim_attributes = []
+          rebuilt_attribute_array                 = rebuilt_schema_instance.scim_attributes
+        end
+
+        schema_attributes.each do | schema_attribute |
+          if schema_attribute.multiValued && schema_attribute.subAttributes&.any?
+            mapped_multivalue_attribute = scim_attributes_map[schema_attribute.name]
+
+            # We expect either an array in the attribute map to correspond with
+            # a multivalued schema attribute, or nothing. If we get some other
+            # non-Array, not-nil thing, it's just ignored.
+            #
+            if mapped_multivalue_attribute.is_a?(Array)
+
+              # A single-entry array with "list using" semantics, for a
+              # collection of an artbirary number of same-class items - e.g.
+              # Groups to which a User belongs.
+              #
+              # If this is an up-to-date mapping, there's a "class" entry that
+              # tells us what the collection is compromised of. If not, then we
+              # check for ActiveRecord collections as a fallback and if that is
+              # the case here, can use reflection to try and find the class. If
+              # all else fails, we drop to generic schema for the collection.
+              #
+              if mapped_multivalue_attribute.first&.dig(:list)
+                associated_resource_class = mapped_multivalue_attribute.first[:class]
+
+                if (
+                  associated_resource_class.nil? &&
+                  class_using_scimitar_mixin < ActiveRecord::Base
+                )
+                  associated_resource_class = class_using_scimitar_mixin
+                    .reflect_on_association(mapped_multivalue_attribute.first[:list])
+                    &.klass
+                end
+
+                if associated_resource_class.nil? || ! associated_resource_class.include?(Scimitar::Resources::Mixin)
+                  rebuilt_attribute_array << schema_attribute
+                else
+                  rebuilt_schema_attribute = schema_attribute.dup()
+                  rebuilt_schema_attribute.subAttributes = []
+                  rebuilt_attribute_array << rebuilt_schema_attribute
+
+                  rebuild_schema_through_mappings(
+                    original_schema_instance:   original_schema_instance,
+                    class_using_scimitar_mixin: associated_resource_class,
+                    scim_attributes_map:        mapped_multivalue_attribute.first[:using],
+                    schema_attributes:          schema_attribute.subAttributes,
+                    rebuilt_attribute_array:    rebuilt_schema_attribute.subAttributes
+                  )
+                end
+
+              # A one-or-more entry array with "match with" semantics, to match
+              # discrete mapped items with a particular value in a particular
+              # field - e.g. an e-mail of type "work" mapping the SCIM "value"
+              # to a local attribute of "work_email_address".
+              #
+              # Mutability or supported attributes here might vary per matched
+              # type. There's no way for SCIM schema to represent that so we
+              # just merge all the "using" mappings together, in order of array
+              # appearance, and have that combined attribute map treated as the
+              # data the schema response will use.
+              #
+              elsif mapped_multivalue_attribute.first&.dig(:match)
+                union_of_mappings = {}
+
+                mapped_multivalue_attribute.each do | mapped_multivalue_attribute_description |
+                  union_of_mappings.merge!(mapped_multivalue_attribute_description[:using])
+                end
+
+                rebuilt_schema_attribute = schema_attribute.dup()
+                rebuilt_schema_attribute.subAttributes = []
+                rebuilt_attribute_array << rebuilt_schema_attribute
+
+                rebuild_schema_through_mappings(
+                  original_schema_instance:   original_schema_instance,
+                  class_using_scimitar_mixin: class_using_scimitar_mixin,
+                  scim_attributes_map:        union_of_mappings,
+                  schema_attributes:          schema_attribute.subAttributes,
+                  rebuilt_attribute_array:    rebuilt_schema_attribute.subAttributes
+                )
+              end
+            end
+
+          elsif schema_attribute.subAttributes&.any?
+            mapped_subattributes = scim_attributes_map[schema_attribute.name]
+
+            if mapped_subattributes.is_a?(Hash)
+              rebuilt_schema_attribute = schema_attribute.dup()
+              rebuilt_schema_attribute.subAttributes = []
+              rebuilt_attribute_array << rebuilt_schema_attribute
+
+              rebuild_schema_through_mappings(
+                original_schema_instance:   original_schema_instance,
+                class_using_scimitar_mixin: class_using_scimitar_mixin,
+                scim_attributes_map:        mapped_subattributes,
+                schema_attributes:          schema_attribute.subAttributes,
+                rebuilt_attribute_array:    rebuilt_schema_attribute.subAttributes
+              )
+            end
+
+          else
+            mapped_attribute = scim_attributes_map[schema_attribute.name]
+
+            unless mapped_attribute.nil?
+              rebuilt_schema_attribute = schema_attribute.dup()
+              has_mapped_reader        = true
+              has_mapped_writer        = false
+
+              if mapped_attribute.is_a?(String) || mapped_attribute.is_a?(Symbol)
+                has_mapped_reader = class_using_scimitar_mixin.new.respond_to?(mapped_attribute)
+                has_mapped_writer = class_using_scimitar_mixin.new.respond_to?("#{mapped_attribute}=")
+              end
+
+              # The schema is taken as the primary source of truth, leading to
+              # a matrix of "do we override it or not?" based on who is the
+              # more limited. When both have the same mutability there is no
+              # more work to do, so we just need to consider differences:
+              #
+              # Actual class support   Schema says   Result
+              # =============================================================
+              # readWrite              readOnly      readOnly  (schema wins)
+              # readWrite              writeOnly     writeOnly (schema wins)
+              # readOnly               readWrite     readOnly  (class wins)
+              # writeOnly              readWrite     writeOnly (class wins)
+              #
+              # Those cases are easy. But there are gnarly cases too, where we
+              # have no good answer and the class's mapped implementation is in
+              # essence broken compared to the schema. Since it is not useful
+              # to insist on the schema's not-reality version, the class wins.
+              #
+              # Actual class support   Schema says   Result
+              # ====================== =======================================
+              # readOnly               writeOnly     readOnly  (class "wins")
+              # writeOnly              readOnly      writeOnly (class "wins")
+
+              schema_attribute_mutability = schema_attribute.mutability.downcase
+
+              if has_mapped_reader && has_mapped_writer
+                #
+                # Read-write Nothing to do. Schema always "wins" by matching or
+                # being more restrictive than the class's actual abilities.
+
+              elsif has_mapped_reader && ! has_mapped_writer
+                #
+                # Read-only. Class is more restrictive if schema is 'readWrite'
+                # or if there's the broken clash of schema 'writeOnly'.
+                #
+                if schema_attribute_mutability == 'readwrite' || schema_attribute_mutability == 'writeonly'
+                  rebuilt_schema_attribute.mutability = 'readOnly'
+                end
+
+              elsif has_mapped_writer && ! has_mapped_reader
+                #
+                # Opposite to the above case.
+                #
+                if schema_attribute_mutability == 'readwrite' || schema_attribute_mutability == 'readonly'
+                  rebuilt_schema_attribute.mutability = 'writeOnly'
+                end
+
+                # ...else we cannot fathom how this class works - it appears to
+                # have no read or write accessor for the mapped attribute. Keep
+                # the schema's declaration as-is.
+                #
+              end
+
+              rebuilt_attribute_array << rebuilt_schema_attribute
+            end
+          end
+        end
+
+        return rebuilt_schema_instance # (meaningless except for topmost call)
+      end
 
   end
 end

--- a/app/controllers/scimitar/schemas_controller.rb
+++ b/app/controllers/scimitar/schemas_controller.rb
@@ -20,7 +20,7 @@ module Scimitar
 
       # Now we either have a simple render method, or a complex one.
       #
-      schema_to_render = if Scimitar.engine_configuration.schema_list_from_attribute_mappings.empty?
+      schemas_to_render = if Scimitar.engine_configuration.schema_list_from_attribute_mappings.empty?
         list
       else
         self.redraw_schema_list_using_mappings(list)
@@ -30,10 +30,10 @@ module Scimitar
         schemas: [
             'urn:ietf:params:scim:api:messages:2.0:ListResponse'
         ],
-        totalResults: schema_to_render.size,
+        totalResults: schemas_to_render.size,
         startIndex:   1,
-        itemsPerPage: schema_to_render.size,
-        Resources:    schema_to_render
+        itemsPerPage: schemas_to_render.size,
+        Resources:    schemas_to_render
       })
     end
 

--- a/app/models/scimitar/engine_configuration.rb
+++ b/app/models/scimitar/engine_configuration.rb
@@ -14,6 +14,7 @@ module Scimitar
       :application_controller_mixin,
       :exception_reporter,
       :optional_value_fields_required,
+      :schema_list_from_attribute_mappings,
     )
 
     def initialize(attributes = {})
@@ -22,7 +23,8 @@ module Scimitar
       # Set defaults that may be overridden by the initializer.
       #
       defaults = {
-        optional_value_fields_required: true
+        optional_value_fields_required:      true,
+        schema_list_from_attribute_mappings: []
       }
 
       super(defaults.merge(attributes))

--- a/app/models/scimitar/resources/mixin.rb
+++ b/app/models/scimitar/resources/mixin.rb
@@ -139,11 +139,12 @@ module Scimitar
     #       # ...
     #       groups: [
     #         {
-    #           list: :users,          # <-- i.e. Team.users,
+    #           list:  :users,         # <-- i.e. Team.users,
     #           using: {
     #             value:   :id,        # <-- i.e. Team.users[n].id
     #             display: :full_name  # <-- i.e. Team.users[n].full_name
     #           },
+    #           class: Team, # Optional; see below
     #           find_with: -> (scim_list_entry) {...} # See below
     #         }
     #       ],
@@ -159,7 +160,10 @@ module Scimitar
     # example above, "find_with"'s Proc might look at a SCIM entry value which
     # is expected to be a user ID and find that User. The mapped set of User
     # data thus found would be written back with "#users=", due to the ":list"
-    # key declaring the method name ":users".
+    # key declaring the method name ":users". The optional "class" key is
+    # recommended but not really *needed* unless the configuration option
+    # Scimitar::EngineConfiguration::schema_list_from_attribute_mappings is
+    # defined; see documentation of that option for more information.
     #
     # Note that you can only use either:
     #
@@ -176,7 +180,8 @@ module Scimitar
     # == scim_mutable_attributes
     #
     # Define this method to return a Set (preferred) or Array of names of
-    # attributes which may be written in the mixing-in class.
+    # attributes which may be written in the mixing-in class. The names MUST be
+    # expressed as Symbols, *not* Strings.
     #
     # If you return +nil+, it is assumed that +any+ attribute mapped by
     # ::scim_attributes_map which has a write accessor will be eligible for
@@ -291,7 +296,7 @@ module Scimitar
         # the result in an instance variable.
         #
         def scim_mutable_attributes
-          @scim_mutable_attributes ||= self.class.scim_mutable_attributes()
+          @scim_mutable_attributes ||= self.class.scim_mutable_attributes()&.map(&:to_sym)
 
           if @scim_mutable_attributes.nil?
             @scim_mutable_attributes = Set.new

--- a/config/initializers/scimitar.rb
+++ b/config/initializers/scimitar.rb
@@ -106,6 +106,47 @@ Rails.application.config.to_prepare do # (required for >= Rails 7 / Zeitwerk)
     # whatever that means for you receiving system in your model code.
     #
     #     optional_value_fields_required: false
+
+    # The SCIM standard `/Schemas` endpoint lists, by default, all known schema
+    # definitions with the mutabilty (read-write, read-only, write-only) state
+    # described by those definitions, and includes all defined attributes. For
+    # user-defined schema, this will typically exactly match your underlying
+    # mapped attribute and model capability - it wouldn't make sense to define
+    # your own schema that misrepresented the implementation! For core SCIM RFC
+    # schema, though, you might want to only list actually mapped attributes.
+    # Further, if you happen to have a non-compliant implementation especially
+    # in relation to mutability of some attributes, you may want to report that
+    # accurately in the '/Schemas' list, for auto-discovery purposes. To switch
+    # to a significantly slower but more accurate render method for the list,
+    # driven by your resource subclasses and their attribute maps, set:
+    #
+    #     schema_list_from_attribute_mappings: [...array...]
+    #
+    # ...where you provide an Array of *models*, your classes that include the
+    # Scimitar::Resources::Mixin module and, therefore, define an attribute map
+    # translating SCIM schema attributes into actual implemented data. These
+    # must *uniquely* describe, via the Scimitar resources they each declare in
+    # their Scimitar::Resources::Mixin::scim_resource_type implementation, the
+    # set of schemas and extended schemas you want to render. Should resources
+    # share schema, the '/Schemas' endpoint will fail since it cannot determine
+    # which model attribute map it should use and it needs the map in order to
+    # resolve the differences (if any) between what the schema might say, and
+    # what the actual underlying model supports.
+    #
+    # It is further _very_ _strongly_ _recommended_ that, for any
+    # +scim_attributes_map+ containing a collection which has "list:" key (for
+    # an associative array of zero or more entities; the Groups to which a User
+    # might belong is a good example) then you should also specify the "class:"
+    # key, giving the class used for objects in that associated collection. The
+    # class *must* include Scimitar::Resources::Mixin, since its own attribute
+    # map is consulted in order to render the part of the schema describing
+    # those associated properties in the owning resource. If you don't do this,
+    # and if you're using ActiveRecord, then Scimitar attempts association
+    # reflection to determine the collection class - but that's more fragile
+    # than just being told the exact class in the attribute map. No matter how
+    # this class is determined, though, it must be possible to create a simple
+    # instance with +new+ and no parameters, since that's needed in order to
+    # call Scimitar::Resources::Mixin#scim_mutable_attributes.
   })
 
 end

--- a/spec/apps/dummy/app/models/mock_user.rb
+++ b/spec/apps/dummy/app/models/mock_user.rb
@@ -82,8 +82,11 @@ class MockUser < ActiveRecord::Base
           }
         },
       ],
-      groups: [ # NB read-only, so no :find_with key
+      groups: [
         {
+          # Read-only, so no :find_with key. There's no 'class' specified here
+          # either, to help test the "/Schemas" endpoint's reflection code.
+          #
           list:  :mock_groups,
           using: {
             value:   :id,

--- a/spec/apps/dummy/app/models/mock_user.rb
+++ b/spec/apps/dummy/app/models/mock_user.rb
@@ -49,6 +49,7 @@ class MockUser < ActiveRecord::Base
       externalId: :scim_uid,
       userName:   :username,
       password:   :password,
+      active:     :is_active,
       name:       {
         givenName:  :first_name,
         familyName: :last_name
@@ -90,14 +91,14 @@ class MockUser < ActiveRecord::Base
           }
         }
       ],
-      active: :is_active,
-      primaryEmail: :scim_primary_email,
 
       # Custom extension schema - see configuration in
       # "spec/apps/dummy/config/initializers/scimitar.rb".
       #
       organization: :organization,
       department:   :department,
+      primaryEmail: :scim_primary_email,
+
       manager:      :manager,
 
       userGroups: [

--- a/spec/controllers/scimitar/schemas_controller_spec.rb
+++ b/spec/controllers/scimitar/schemas_controller_spec.rb
@@ -12,97 +12,360 @@ RSpec.describe Scimitar::SchemasController do
   end
 
   context '#index' do
-    it 'returns a valid ListResponse' do
-      get :index, params: { format: :scim }
-      expect(response).to be_ok
-
-      parsed_body  = JSON.parse(response.body)
-      schema_count = parsed_body['Resources']&.size
-
-      expect(parsed_body['schemas'     ]).to match_array(['urn:ietf:params:scim:api:messages:2.0:ListResponse'])
-      expect(parsed_body['totalResults']).to eql(schema_count)
-      expect(parsed_body['itemsPerPage']).to eql(schema_count)
-      expect(parsed_body['startIndex'  ]).to eql(1)
-    end
-
-    it 'returns a collection of supported schemas' do
-      get :index, params: { format: :scim }
-      expect(response).to be_ok
-
-      parsed_body = JSON.parse(response.body)
-      expect(parsed_body['Resources']&.size).to eql(4)
-
-      schema_names = parsed_body['Resources'].map {|schema| schema['name']}
-      expect(schema_names).to match_array(['User', 'EnterpriseExtendedUser', 'ManagementExtendedUser', 'Group'])
-    end
-
-    it 'returns only the User schema when its id is provided' do
-      get :index, params: { name: Scimitar::Schema::User.id, format: :scim }
-      expect(response).to be_ok
-
-      parsed_body = JSON.parse(response.body)
-      expect(parsed_body.dig('Resources', 0, 'name')).to eql('User')
-    end
-
-    it 'includes the controller customised schema location' do
-      get :index, params: { name: Scimitar::Schema::User.id, format: :scim }
-      expect(response).to be_ok
-
-      parsed_body = JSON.parse(response.body)
-      expect(parsed_body.dig('Resources', 0, 'meta', 'location')).to eq scim_schemas_url(name: Scimitar::Schema::User.id, test: 1)
-    end
-
-    it 'returns only the Group schema when its id is provided' do
-      get :index, params: { name: Scimitar::Schema::Group.id, format: :scim }
-      expect(response).to be_ok
-
-      parsed_body = JSON.parse(response.body)
-
-      expect(parsed_body['Resources'   ]&.size).to eql(1)
-      expect(parsed_body['totalResults']      ).to eql(1)
-      expect(parsed_body['itemsPerPage']      ).to eql(1)
-      expect(parsed_body['startIndex'  ]      ).to eql(1)
-
-      expect(parsed_body.dig('Resources', 0, 'name')).to eql('Group')
-    end
-
-    context 'with custom resource types' do
-      around :each do | example |
-        example.run()
-      ensure
-        Scimitar::Engine.reset_custom_resources
-      end
-
-      it 'returns only the License schemas when its id is provided' do
-        license_schema = Class.new(Scimitar::Schema::Base) do
-          def initialize(options = {})
-          super(name: 'License',
-                id: self.class.id,
-                description: 'Represents a License')
-          end
-          def self.id
-            'License'
-          end
-          def self.scim_attributes
-            []
-          end
-        end
-
-        license_resource = Class.new(Scimitar::Resources::Base) do
-          set_schema license_schema
-          def self.endpoint
-            '/Gaga'
-          end
-        end
-
-        Scimitar::Engine.add_custom_resource(license_resource)
-
-        get :index, params: { name: license_schema.id, format: :scim }
+    shared_examples 'a Schema list which' do
+      it 'returns a valid ListResponse' do
+        get :index, params: { format: :scim }
         expect(response).to be_ok
-        parsed_body = JSON.parse(response.body)
-        expect(parsed_body.dig('Resources', 0, 'name')).to eql('License')
+
+        parsed_body  = JSON.parse(response.body)
+        schema_count = parsed_body['Resources']&.size
+
+        expect(parsed_body['schemas'     ]).to match_array(['urn:ietf:params:scim:api:messages:2.0:ListResponse'])
+        expect(parsed_body['totalResults']).to eql(schema_count)
+        expect(parsed_body['itemsPerPage']).to eql(schema_count)
+        expect(parsed_body['startIndex'  ]).to eql(1)
       end
-    end # "context 'with custom resource types' do"
+
+      it 'returns a collection of supported schemas' do
+        get :index, params: { format: :scim }
+        expect(response).to be_ok
+
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body['Resources']&.size).to eql(4)
+
+        schema_names = parsed_body['Resources'].map {|schema| schema['name']}
+        expect(schema_names).to match_array(['User', 'EnterpriseExtendedUser', 'ManagementExtendedUser', 'Group'])
+      end
+
+      it 'returns only the User schema when its ID is provided' do
+        get :index, params: { name: Scimitar::Schema::User.id, format: :scim }
+        expect(response).to be_ok
+
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body.dig('Resources', 0, 'name')).to eql('User')
+      end
+
+      it 'includes the controller customised schema location' do
+        get :index, params: { name: Scimitar::Schema::User.id, format: :scim }
+        expect(response).to be_ok
+
+        parsed_body = JSON.parse(response.body)
+        expect(parsed_body.dig('Resources', 0, 'meta', 'location')).to eq scim_schemas_url(name: Scimitar::Schema::User.id, test: 1)
+      end
+
+      it 'returns only the Group schema when its ID is provided' do
+        get :index, params: { name: Scimitar::Schema::Group.id, format: :scim }
+        expect(response).to be_ok
+
+        parsed_body = JSON.parse(response.body)
+
+        expect(parsed_body['Resources'   ]&.size).to eql(1)
+        expect(parsed_body['totalResults']      ).to eql(1)
+        expect(parsed_body['itemsPerPage']      ).to eql(1)
+        expect(parsed_body['startIndex'  ]      ).to eql(1)
+
+        expect(parsed_body.dig('Resources', 0, 'name')).to eql('Group')
+      end
+    end
+
+    context 'with default engine configuration of schema_list_from_attribute_mappings undefined' do
+      it_behaves_like 'a Schema list which'
+
+      it 'returns all attributes' do
+        get :index, params: { name: Scimitar::Schema::User.id, format: :scim }
+        expect(response).to be_ok
+
+        parsed_body = JSON.parse(response.body)
+        user_attrs  = parsed_body['Resources'].find { | r | r['name'] == 'User' }
+
+        expect(user_attrs['attributes'].find { | a | a['name'] == 'ims'              }).to be_present
+        expect(user_attrs['attributes'].find { | a | a['name'] == 'entitlements'     }).to be_present
+        expect(user_attrs['attributes'].find { | a | a['name'] == 'x509Certificates' }).to be_present
+
+        name_attr = user_attrs['attributes'].find { | a | a['name'] == 'name' }
+
+        expect(name_attr['subAttributes'].find { | s | s['name'] == 'honorificPrefix' }).to be_present
+        expect(name_attr['subAttributes'].find { | s | s['name'] == 'honorificSuffix' }).to be_present
+      end
+
+      context 'with custom resource types' do
+        around :each do | example |
+          example.run()
+        ensure
+          Scimitar::Engine.reset_custom_resources
+        end
+
+        it 'returns only the License schemas when its ID is provided' do
+          license_schema = Class.new(Scimitar::Schema::Base) do
+            def initialize(options = {})
+              super(name: 'License', id: self.class.id(), description: 'Represents a License')
+            end
+            def self.id; 'urn:ietf:params:scim:schemas:license'; end
+            def self.scim_attributes; []; end
+          end
+
+          license_resource = Class.new(Scimitar::Resources::Base) do
+            set_schema(license_schema)
+            def self.endpoint; '/License'; end
+          end
+
+          Scimitar::Engine.add_custom_resource(license_resource)
+
+          get :index, params: { name: license_schema.id, format: :scim }
+          expect(response).to be_ok
+
+          parsed_body = JSON.parse(response.body)
+          expect(parsed_body.dig('Resources', 0, 'name')).to eql('License')
+        end
+      end # "context 'with custom resource types' do"
+    end # "context 'with default engine configuration of schema_list_from_attribute_mappings undefined' do"
+
+    context 'with engine configuration of schema_list_from_attribute_mappings set' do
+      context 'standard resources' do
+        around :each do | example |
+          old_config = Scimitar.engine_configuration.schema_list_from_attribute_mappings
+          Scimitar.engine_configuration.schema_list_from_attribute_mappings = [
+            MockUser,
+            MockGroup
+          ]
+          example.run()
+        ensure
+          Scimitar.engine_configuration.schema_list_from_attribute_mappings = old_config
+        end
+
+        it_behaves_like 'a Schema list which'
+
+        it 'returns only mapped attributes' do
+          get :index, params: { name: Scimitar::Schema::User.id, format: :scim }
+          expect(response).to be_ok
+
+          parsed_body   = JSON.parse(response.body)
+          user_attrs    = parsed_body['Resources'].find { | r | r['name'] == 'User'     }
+          password_attr = user_attrs['attributes'].find { | a | a['name'] == 'password' }
+
+          expect(password_attr['mutability']).to eql('writeOnly')
+
+          expect(user_attrs['attributes'].find { | a | a['name'] == 'ims'              }).to_not be_present
+          expect(user_attrs['attributes'].find { | a | a['name'] == 'entitlements'     }).to_not be_present
+          expect(user_attrs['attributes'].find { | a | a['name'] == 'x509Certificates' }).to_not be_present
+
+          name_attr = user_attrs['attributes'].find { | a | a['name'] == 'name' }
+
+          expect(name_attr['subAttributes'].find { | s | s['name'] == 'givenName'       }).to     be_present
+          expect(name_attr['subAttributes'].find { | s | s['name'] == 'familyName'      }).to     be_present
+          expect(name_attr['subAttributes'].find { | s | s['name'] == 'honorificPrefix' }).to_not be_present
+          expect(name_attr['subAttributes'].find { | s | s['name'] == 'honorificSuffix' }).to_not be_present
+
+          emails_attr  =  user_attrs['attributes'   ].find { | a | a['name'] == 'emails'  }
+          value_attr   = emails_attr['subAttributes'].find { | a | a['name'] == 'value'   }
+          primary_attr = emails_attr['subAttributes'].find { | a | a['name'] == 'primary' }
+
+          expect(  value_attr['mutability']).to eql('readWrite')
+          expect(primary_attr['mutability']).to eql('readOnly')
+
+          expect(emails_attr['subAttributes'].find { | s | s['name'] == 'type'    }).to_not be_present
+          expect(emails_attr['subAttributes'].find { | s | s['name'] == 'display' }).to_not be_present
+
+          groups_attr  =  user_attrs['attributes'   ].find { | a | a['name'] == 'groups'  }
+          value_attr   = groups_attr['subAttributes'].find { | a | a['name'] == 'value'   }
+          display_attr = groups_attr['subAttributes'].find { | a | a['name'] == 'display' }
+
+          expect(  value_attr['mutability']).to eql('readOnly')
+          expect(display_attr['mutability']).to eql('readOnly')
+        end
+      end
+
+      context 'with custom resource types' do
+        let(:license_schema) {
+          Class.new(Scimitar::Schema::Base) do
+            def initialize(options = {})
+              super(
+                id:              self.class.id(),
+                name:            'License',
+                description:     'Represents a license',
+                scim_attributes: self.class.scim_attributes
+              )
+            end
+            def self.id; 'urn:ietf:params:scim:schemas:license'; end
+            def self.scim_attributes
+              [
+                Scimitar::Schema::Attribute.new(name: 'licenseNumber',  type: 'string'),
+                Scimitar::Schema::Attribute.new(name: 'licenseExpired', type: 'boolean', mutability: 'readOnly'),
+              ]
+            end
+          end
+        }
+
+        let(:license_resource) {
+          local_var_license_schema = license_schema()
+
+          Class.new(Scimitar::Resources::Base) do
+            set_schema(local_var_license_schema)
+            def self.endpoint; '/License'; end
+          end
+        }
+
+        let(:license_model_base) {
+          local_var_license_resource = license_resource()
+
+          Class.new do
+            singleton_class.class_eval do
+              define_method(:scim_resource_type) { local_var_license_resource }
+            end
+          end
+        }
+
+        around :each do | example |
+          old_config = Scimitar.engine_configuration.schema_list_from_attribute_mappings
+          Scimitar::Engine.add_custom_resource(license_resource())
+          example.run()
+        ensure
+          Scimitar.engine_configuration.schema_list_from_attribute_mappings = old_config
+          Scimitar::Engine.reset_custom_resources
+        end
+
+        context 'with an empty attribute map' do
+          it 'returns no attributes' do
+            license_model = Class.new(license_model_base()) do
+              attr_accessor :license_number
+
+              def self.scim_mutable_attributes; nil; end
+              def self.scim_queryable_attributes; nil; end
+              def self.scim_attributes_map; {}; end # Empty map
+
+              include Scimitar::Resources::Mixin
+            end
+
+            Scimitar.engine_configuration.schema_list_from_attribute_mappings = [license_model]
+
+            get :index, params: { format: :scim }
+            expect(response).to be_ok
+
+            parsed_body = JSON.parse(response.body)
+
+            expect(parsed_body.dig('Resources', 0, 'name'      )).to eql('License')
+            expect(parsed_body.dig('Resources', 0, 'attributes')).to be_empty
+          end
+        end # "context 'with an empty attribute map' do"
+
+        context 'with a defined attribute map' do
+          it 'returns only the License schemas when its ID is provided' do
+            license_model = Class.new(license_model_base()) do
+              attr_accessor :license_number
+
+              def self.scim_mutable_attributes; nil; end
+              def self.scim_queryable_attributes; nil; end
+              def self.scim_attributes_map # Simple map
+                { licenseNumber: :license_number }
+              end
+
+              include Scimitar::Resources::Mixin
+            end
+
+            Scimitar.engine_configuration.schema_list_from_attribute_mappings = [license_model]
+
+            get :index, params: { format: :scim }
+            expect(response).to be_ok
+
+            parsed_body = JSON.parse(response.body)
+
+            expect(parsed_body.dig('Resources', 0, 'name'                       )).to eql('License')
+            expect(parsed_body.dig('Resources', 0, 'attributes').size            ).to eql(1)
+            expect(parsed_body.dig('Resources', 0, 'attributes', 0, 'name'      )).to eql('licenseNumber')
+            expect(parsed_body.dig('Resources', 0, 'attributes', 0, 'mutability')).to eql('readWrite')
+          end
+        end # "context 'with a defined attribute map' do"
+
+        context 'with mutability overridden' do
+          it 'returns read-only when expected' do
+            license_model = Class.new(license_model_base()) do
+              attr_accessor :license_number
+
+              def self.scim_mutable_attributes; []; end # Note empty array, NOT "nil" - no mutable attributes
+              def self.scim_queryable_attributes; nil; end
+              def self.scim_attributes_map
+                { licenseNumber: :license_number }
+              end
+
+              include Scimitar::Resources::Mixin
+            end
+
+            Scimitar.engine_configuration.schema_list_from_attribute_mappings = [license_model]
+
+            get :index, params: { format: :scim }
+            expect(response).to be_ok
+
+            parsed_body = JSON.parse(response.body)
+
+            expect(parsed_body.dig('Resources', 0, 'name'                       )).to eql('License')
+            expect(parsed_body.dig('Resources', 0, 'attributes').size            ).to eql(1)
+            expect(parsed_body.dig('Resources', 0, 'attributes', 0, 'name'      )).to eql('licenseNumber')
+            expect(parsed_body.dig('Resources', 0, 'attributes', 0, 'mutability')).to eql('readOnly')
+          end
+
+          it 'returns write-only when expected' do
+            license_model = Class.new(license_model_base()) do
+              attr_writer :license_number # Writer only, no reader
+
+              def self.scim_mutable_attributes; nil; end
+              def self.scim_queryable_attributes; nil; end
+              def self.scim_attributes_map
+                { licenseNumber: :license_number }
+              end
+
+              include Scimitar::Resources::Mixin
+            end
+
+            Scimitar.engine_configuration.schema_list_from_attribute_mappings = [license_model]
+
+            get :index, params: { format: :scim }
+            expect(response).to be_ok
+
+            parsed_body = JSON.parse(response.body)
+
+            expect(parsed_body.dig('Resources', 0, 'name'                       )).to eql('License')
+            expect(parsed_body.dig('Resources', 0, 'attributes').size            ).to eql(1)
+            expect(parsed_body.dig('Resources', 0, 'attributes', 0, 'name'      )).to eql('licenseNumber')
+            expect(parsed_body.dig('Resources', 0, 'attributes', 0, 'mutability')).to eql('writeOnly')
+          end
+
+          it 'handles conflicts via reality-wins' do
+            license_model = Class.new(license_model_base()) do
+              def self.scim_mutable_attributes; [:licence_expired]; end
+              def self.scim_queryable_attributes; nil; end
+              def self.scim_attributes_map
+                { licenseNumber: :license_number, licenseExpired: :licence_expired }
+              end
+
+              include Scimitar::Resources::Mixin
+            end
+
+            Scimitar.engine_configuration.schema_list_from_attribute_mappings = [license_model]
+
+            get :index, params: { format: :scim }
+            expect(response).to be_ok
+
+            parsed_body = JSON.parse(response.body)
+            attributes  = parsed_body.dig('Resources', 0, 'attributes')
+
+            expect(parsed_body.dig('Resources', 0, 'name')).to eql('License')
+            expect(attributes.size).to eql(2)
+
+            number_attr = attributes.find { | a | a['name'] == 'licenseNumber'  }
+            expiry_attr = attributes.find { | a | a['name'] == 'licenseExpired' }
+
+            # Number attribute - no reader or writer, so code has to shrug and
+            # say "it's broken, so I'll quote the schema verbatim'.
+            #
+            # Expiry attribute - is read-only in schema, but we declare it as a
+            # writable attribute and provide no reader. This clashes badly; the
+            # schema read-only declaration is ignored in favour of reality.
+            #
+            expect(number_attr['mutability']).to eql('readWrite')
+            expect(expiry_attr['mutability']).to eql('writeOnly')
+          end
+        end # "context 'with mutability overridden' do"
+      end # "context 'with custom resource types' do"
+    end # "context 'with engine configuration of schema_list_from_attribute_mappings: true' do"
   end # "context '#index' do
 end
-

--- a/spec/models/scimitar/resources/base_spec.rb
+++ b/spec/models/scimitar/resources/base_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Scimitar::Resources::Base do
   context 'basic operation' do
     FirstCustomSchema = Class.new(Scimitar::Schema::Base) do
       def self.id
-        'custom-id'
+        'urn:ietf:params:scim:schemas:custom-id'
       end
 
       def self.scim_attributes
@@ -125,7 +125,7 @@ RSpec.describe Scimitar::Resources::Base do
 
         result = resource.as_json
 
-        expect(result['schemas']             ).to eql(['custom-id'])
+        expect(result['schemas']             ).to eql(['urn:ietf:params:scim:schemas:custom-id'])
         expect(result['meta']['resourceType']).to eql('CustomResourse')
         expect(result['errors']              ).to be_nil
       end
@@ -144,7 +144,7 @@ RSpec.describe Scimitar::Resources::Base do
 
         result = resource.as_json
 
-        expect(result['schemas']             ).to eql(['custom-id'])
+        expect(result['schemas']             ).to eql(['urn:ietf:params:scim:schemas:custom-id'])
         expect(result['meta']['resourceType']).to eql('CustomResourse')
         expect(result['errors']              ).to be_nil
         expect(result['name']                ).to be_present
@@ -295,7 +295,7 @@ RSpec.describe Scimitar::Resources::Base do
     context 'of custom schema' do
       ThirdCustomSchema = Class.new(Scimitar::Schema::Base) do
         def self.id
-          'custom-id'
+          'urn:ietf:params:scim:schemas:custom-id'
         end
 
         def self.scim_attributes
@@ -305,7 +305,7 @@ RSpec.describe Scimitar::Resources::Base do
 
       ExtensionSchema = Class.new(Scimitar::Schema::Base) do
         def self.id
-          'urn:extension'
+          'urn:ietf:params:scim:schemas:extension'
         end
 
         def self.scim_attributes
@@ -333,13 +333,13 @@ RSpec.describe Scimitar::Resources::Base do
 
       context '#initialize' do
         it 'allows setting extension attributes' do
-          resource = resource_class.new('urn:extension' => {relationship: 'GAGA'})
+          resource = resource_class.new('urn:ietf:params:scim:schemas:extension' => {relationship: 'GAGA'})
           expect(resource.relationship).to eql('GAGA')
         end
 
         it 'allows setting complex extension attributes' do
           user_groups = [{ value: '123' }, { value: '456'}]
-          resource = resource_class.new('urn:extension' => {userGroups: user_groups})
+          resource = resource_class.new('urn:ietf:params:scim:schemas:extension' => {userGroups: user_groups})
           expect(resource.userGroups.map(&:value)).to eql(['123', '456'])
         end
       end # "context '#initialize' do"
@@ -348,8 +348,8 @@ RSpec.describe Scimitar::Resources::Base do
         it 'namespaces the extension attributes' do
           resource = resource_class.new(relationship: 'GAGA')
           hash = resource.as_json
-          expect(hash["schemas"]).to eql(['custom-id', 'urn:extension'])
-          expect(hash["urn:extension"]).to eql("relationship" => 'GAGA')
+          expect(hash["schemas"]).to eql(['urn:ietf:params:scim:schemas:custom-id', 'urn:ietf:params:scim:schemas:extension'])
+          expect(hash["urn:ietf:params:scim:schemas:extension"]).to eql("relationship" => 'GAGA')
         end
       end # "context '#as_json' do"
 
@@ -362,10 +362,10 @@ RSpec.describe Scimitar::Resources::Base do
 
         context 'validation' do
           it 'validates into custom schema' do
-            resource = resource_class.new('urn:extension' => {})
+            resource = resource_class.new('urn:ietf:params:scim:schemas:extension' => {})
             expect(resource.valid?).to eql(false)
 
-            resource = resource_class.new('urn:extension' => {relationship: 'GAGA'})
+            resource = resource_class.new('urn:ietf:params:scim:schemas:extension' => {relationship: 'GAGA'})
             expect(resource.relationship).to eql('GAGA')
             expect(resource.valid?).to eql(true)
           end

--- a/spec/models/scimitar/resources/base_validation_spec.rb
+++ b/spec/models/scimitar/resources/base_validation_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Scimitar::Resources::Base do
   context '#valid?' do
     MyCustomSchema = Class.new(Scimitar::Schema::Base) do
       def self.id
-        'custom-id'
+        'urn:ietf:params:scim:schemas:custom-id'
       end
 
       class NameWithRequirementsSchema < Scimitar::Schema::Base

--- a/spec/requests/engine_spec.rb
+++ b/spec/requests/engine_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe Scimitar::Engine do
         def initialize(options = {})
           super(name: 'License', id: self.class.id(), description: 'Represents a License')
         end
-        def self.id;              'License'; end
-        def self.scim_attributes; [];        end
+        def self.id; 'urn:ietf:params:scim:schemas:license'; end
+        def self.scim_attributes; []; end
       end
 
       @license_resource = Class.new(Scimitar::Resources::Base) do


### PR DESCRIPTION
Address #119 with opt-in configuration.

Reviewing by starting with the diff of `config/initializers/scimitar.rb` is recommended, as this explains the new configuration option and, with that, the controller code which uses it will obviously make more sense.

Hiding white space changes will reduce diff noise in the tests, where a chunk of code got indented into a new `context`.