### PR TITLE
Modify response of ResourceTypes endpoint

### DIFF
--- a/app/controllers/scimitar/resource_types_controller.rb
+++ b/app/controllers/scimitar/resource_types_controller.rb
@@ -5,7 +5,13 @@ module Scimitar
         resource.resource_type(scim_resource_type_url(name: resource.resource_type_id))
       end
 
-      render json: resource_types
+      render json: {
+        schemas: [
+            'urn:ietf:params:scim:api:messages:2.0:ListResponse'
+        ],
+        totalResults: resource_types.size,
+        Resources:    resource_types
+      }
     end
 
     def show

--- a/spec/controllers/scimitar/resource_types_controller_spec.rb
+++ b/spec/controllers/scimitar/resource_types_controller_spec.rb
@@ -9,11 +9,15 @@ RSpec.describe Scimitar::ResourceTypesController do
     it 'renders the resource type for user' do
       get :index, format: :scim
       response_hash = JSON.parse(response.body)
-      expected_response = [ Scimitar::Resources::User.resource_type(scim_resource_type_url(name: 'User', test: 1)),
-                            Scimitar::Resources::Group.resource_type(scim_resource_type_url(name: 'Group', test: 1))
-      ].to_json
+      expected_response = {
+        schemas: ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+        totalResults: 2,
+        Resources: [
+          Scimitar::Resources::User.resource_type(scim_resource_type_url(name: 'User', test: 1)),
+          Scimitar::Resources::Group.resource_type(scim_resource_type_url(name: 'Group', test: 1))
+        ]
+      }.to_json
 
-      response_hash = JSON.parse(response.body)
       expect(response_hash).to eql(JSON.parse(expected_response))
     end
 


### PR DESCRIPTION
This modifies the response of /ResourceTypes as described in the RFC here: https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2

I described the problem in more detail in https://github.com/RIPAGlobal/scimitar/issues/146